### PR TITLE
Liquid zero does not equal false

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Python Liquid Change Log
 ========================
 
+Version 1.4.2
+-------------
+
+**Fixes**
+
+- Fixed a potential memory leak from using ``functools.lru_cache`` on a class method.
+  See #63.
+- Fixed a bug with the ``default`` filter. Liquid zero should not be equal to ``False``.
+  The ``default`` filter now returns ``0`` if its left value is zero. Before it would
+  have return its default value. See #62.
+
 Version 1.4.1
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Version 1.4.2
 - Fixed a bug with the ``default`` filter. Liquid zero should not be equal to ``False``.
   The ``default`` filter now returns ``0`` if its left value is zero. Before it would
   have return its default value. See #62.
+- Fixed a bug where boolean expressions would consider Liquid ``0`` and ``false`` to be
+  equal and ``0`` to be falsy. Python Liquid is now consistent with the reference
+  implementation when comparing integers to booleans. See #65.
 
 Version 1.4.1
 -------------

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 # pylint: disable=useless-import-alias,missing-module-docstring
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 try:
     from markupsafe import escape as escape

--- a/liquid/builtin/filters/misc.py
+++ b/liquid/builtin/filters/misc.py
@@ -49,6 +49,10 @@ def default(obj: Any, default_: object = "", *, allow_false: bool = False) -> An
     if hasattr(obj, "__liquid__"):
         _obj = obj.__liquid__()
 
+    # Liquid zero is not falsy.
+    if isinstance(_obj, int) and not isinstance(_obj, bool):
+        return obj
+
     if allow_false is True and _obj is False:
         return obj
 

--- a/liquid/golden/default_filter.py
+++ b/liquid/golden/default_filter.py
@@ -94,4 +94,14 @@ cases = [
         template=r'{{ false | default: allow_false: false, "bar" }}',
         expect="bar",
     ),
+    Case(
+        description="zero is not falsy",
+        template=r'{{ 0 | default: "bar" }}',
+        expect="0",
+    ),
+    Case(
+        description="zero is not falsy with allow_false",
+        template=r'{{ 0 | default: "bar", allow_false: true }}',
+        expect="0",
+    ),
 ]

--- a/liquid/golden/if_tag.py
+++ b/liquid/golden/if_tag.py
@@ -156,4 +156,19 @@ cases = [
         template=(r"{% if true and false and false or true %}hello{% endif %}"),
         expect="",
     ),
+    Case(
+        description=("zero is not equal to false"),
+        template=(r"{% if 0 == false %}Hello{% else %}Goodbye{% endif %}"),
+        expect="Goodbye",
+    ),
+    Case(
+        description=("zero is truthy"),
+        template=(r"{% if 0 %}Hello{% else %}Goodbye{% endif %}"),
+        expect="Hello",
+    ),
+    Case(
+        description=("one is not equal to true"),
+        template=(r"{% if 1 == true %}Hello{% else %}Goodbye{% endif %}"),
+        expect="Goodbye",
+    ),
 ]

--- a/liquid/golden/unless_tag.py
+++ b/liquid/golden/unless_tag.py
@@ -38,4 +38,19 @@ cases = [
         ),
         expect="hello",
     ),
+    Case(
+        description=("zero is not equal to false"),
+        template=(r"{% unless 0 == false %}Hello{% else %}Goodbye{% endunless %}"),
+        expect="Hello",
+    ),
+    Case(
+        description=("zero is truthy"),
+        template=(r"{% unless 0 %}Hello{% else %}Goodbye{% endunless %}"),
+        expect="Goodbye",
+    ),
+    Case(
+        description=("one is not equal to true"),
+        template=(r"{% unless 1 == true %}Hello{% else %}Goodbye{% endunless %}"),
+        expect="Hello",
+    ),
 ]

--- a/tests/filters/test_misc.py
+++ b/tests/filters/test_misc.py
@@ -60,6 +60,24 @@ class NoLiquidDrop:
         return "hello no liquid drop"
 
 
+class FalsyDrop:
+    def __init__(self, val):
+        self.val = val
+
+    def __eq__(self, other):
+        if isinstance(other, bool) and self.val == other:
+            return True
+        if isinstance(other, FalsyDrop) and self.val == other.val:
+            return True
+        return False
+
+    def __str__(self):
+        return "falsy drop"
+
+    def __bool__(self):
+        return False
+
+
 class MiscFilterTestCase(unittest.TestCase):
     """Test miscellaneous filter functions."""
 
@@ -250,6 +268,27 @@ class MiscFilterTestCase(unittest.TestCase):
                 args=["bar"],
                 kwargs={},
                 expect=NoLiquidDrop(False),
+            ),
+            Case(
+                description="zero is not false",
+                val=0,
+                args=["bar"],
+                kwargs={},
+                expect=0,
+            ),
+            Case(
+                description="one is not false or true",
+                val=1,
+                args=["bar"],
+                kwargs={},
+                expect=1,
+            ),
+            Case(
+                description="falsy drop",
+                val=FalsyDrop(0),
+                args=["bar"],
+                kwargs={},
+                expect="bar",
             ),
         ]
 

--- a/tests/test_evaluate_expression.py
+++ b/tests/test_evaluate_expression.py
@@ -489,6 +489,72 @@ class LiquidStatementEvalTestCase(unittest.TestCase):
                 expression="nil == nil",
                 expect=True,
             ),
+            Case(
+                description="zero",
+                context={},
+                expression="0",
+                expect=True,
+            ),
+            Case(
+                description="one",
+                context={},
+                expression="1",
+                expect=True,
+            ),
+            Case(
+                description="zero equals false",
+                context={},
+                expression="0 == false",
+                expect=False,
+            ),
+            Case(
+                description="one equals true",
+                context={},
+                expression="1 == true",
+                expect=False,
+            ),
+            Case(
+                description="true equals one",
+                context={},
+                expression="true == 1",
+                expect=False,
+            ),
+            Case(
+                description="one is less than true",
+                context={},
+                expression="1 < true",
+                expect=False,
+            ),
+            Case(
+                description="zero is less than true",
+                context={},
+                expression="0 < true",
+                expect=False,
+            ),
+            Case(
+                description="one is not equal true",
+                context={},
+                expression="1 != true",
+                expect=True,
+            ),
+            Case(
+                description="zero is not equal false",
+                context={},
+                expression="0 != false",
+                expect=True,
+            ),
+            Case(
+                description="false is not equal zero",
+                context={},
+                expression="false != 0",
+                expect=True,
+            ),
+            Case(
+                description="false is less than string",
+                context={},
+                expression="false < 'false'",
+                expect=False,
+            ),
         ]
 
         self._test(test_cases, tokenize_boolean_expression, parse_boolean_expression)


### PR DESCRIPTION
When used as the left value of the `default` filter, `0` should not be equal to `False`. Fixes #62.

**Expected behaviour**
```liquid
{{ 0 | default: "something" }}
{{ 0 | default: "something", allow_false: true }}
```

**Output**
```plain
0
0
```