### PR TITLE
Guard against long str to int conversion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,13 +1,17 @@
 Python Liquid Change Log
 ========================
 
-Version 1.4.4 (unreleased)
---------------------------
+Version 1.4.4
+-------------
 
 **Fixes**
 
 - Keep comment text for later static analysis when parsing ``{% comment %}`` block tags.
   See `#70 <https://github.com/jg-rp/liquid/issues/70>`_.
+- Guard against DoS by very large str to int conversion. We honour environment variable
+  ``PYTHONINTMAXSTRDIGITS``, or use ``LIQUIDINTMAXSTRDIGITS`` if you want to set
+  Liquid's max digits independently. The default is 4300.
+  See https://github.com/python/cpython/issues/95778
 
 Version 1.4.3
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -130,6 +130,7 @@ Exceptions
 .. autoclass:: liquid.exceptions.Error
 .. autoclass:: liquid.exceptions.LiquidSyntaxError
 .. autoclass:: liquid.exceptions.LiquidTypeError
+.. autoclass:: liquid.exceptions.LiquidValueError
 .. autoclass:: liquid.exceptions.DisabledTagError
 .. autoclass:: liquid.exceptions.NoSuchFilterFunc
 .. autoclass:: liquid.exceptions.FilterArgumentError

--- a/liquid/builtin/filters/string.py
+++ b/liquid/builtin/filters/string.py
@@ -31,6 +31,8 @@ from liquid.filter import with_environment
 from liquid.filter import string_filter
 from liquid.filter import liquid_filter
 
+from liquid.limits import to_int
+
 from liquid.utils.html import strip_tags
 from liquid.utils.text import truncate_chars
 from liquid.utils.text import truncate_words
@@ -193,14 +195,14 @@ def slice_(val: Any, start: Any, length: Any = 1) -> Union[str, List[object]]:
         )
 
     try:
-        start = int(start)
+        start = to_int(start)
     except (ValueError, TypeError) as err:
         raise FilterArgumentError(
             f"slice expected an integer start, found {type(start).__name__}"
         ) from err
 
     try:
-        length = int(length)
+        length = to_int(length)
     except (ValueError, TypeError) as err:
         raise FilterArgumentError(
             f"slice expected an integer length, found {type(length).__name__}"
@@ -266,7 +268,7 @@ def truncate(val: str, num: Any = 50, end: str = "...") -> str:
         raise FilterArgumentError("truncate expected an integer, found Undefined")
 
     try:
-        num = int(num)
+        num = to_int(num)
     except ValueError as err:
         raise FilterArgumentError(
             f"truncate expected an integer, found {type(num).__name__}"
@@ -287,7 +289,7 @@ def truncatewords(val: str, num: Any = 15, end: str = "...") -> str:
         raise FilterArgumentError("truncate expected an integer, found Undefined")
 
     try:
-        num = int(num)
+        num = to_int(num)
     except ValueError as err:
         raise FilterArgumentError(
             f"truncate expected an integer, found {type(num).__name__}"

--- a/liquid/exceptions.py
+++ b/liquid/exceptions.py
@@ -90,7 +90,7 @@ class FilterValueError(Error):
 
 
 class TemplateNotFound(Error):
-    """Excpetion raised when a template could not be found."""
+    """Exception raised when a template could not be found."""
 
     def __str__(self) -> str:
         msg = super().__str__()
@@ -122,6 +122,16 @@ class OutputStreamLimitError(ResourceLimitError):
 class LocalNamespaceLimitError(ResourceLimitError):
     """Exception raised when the maximum size of a render context's local namespace
     has been exceeded."""
+
+
+# LiquidValueError inheriting from LiquidSyntaxError does not make complete sense.
+# The alternative is to have multiple to_int functions that raise more appropriate
+# exceptions depending on whether we are parsing or rendering when attempting to
+# convert long strings to integers.
+
+
+class LiquidValueError(LiquidSyntaxError):
+    """Exception raised when a cast from str to int exceeds the length limit."""
 
 
 class UndefinedError(Error):

--- a/liquid/expression.py
+++ b/liquid/expression.py
@@ -33,6 +33,8 @@ from liquid.exceptions import Error
 from liquid.exceptions import NoSuchFilterFunc
 from liquid.exceptions import FilterValueError
 
+from liquid.limits import to_int
+
 # pylint: disable=missing-class-docstring too-few-public-methods
 
 
@@ -280,12 +282,12 @@ class RangeLiteral(Expression):
 
     def _make_range(self, start: Any, stop: Any) -> range:
         try:
-            start = int(start)
+            start = to_int(start)
         except ValueError:
             start = 0
 
         try:
-            stop = int(stop)
+            stop = to_int(stop)
         except ValueError:
             stop = 0
 

--- a/liquid/expressions/common.py
+++ b/liquid/expressions/common.py
@@ -39,6 +39,7 @@ from liquid.token import TOKEN_RANGE
 from liquid.token import TOKEN_STRING
 
 from liquid.exceptions import LiquidSyntaxError
+from liquid.limits import to_int
 
 if TYPE_CHECKING:
     from liquid.expressions.stream import TokenStream
@@ -103,7 +104,7 @@ def parse_string_literal(stream: "TokenStream") -> StringLiteral:
 
 def parse_integer_literal(stream: "TokenStream") -> IntegerLiteral:
     """Read an integer from the token stream."""
-    return IntegerLiteral(value=int(stream.current[2]))
+    return IntegerLiteral(value=to_int(stream.current[2]))
 
 
 def parse_float_literal(stream: "TokenStream") -> FloatLiteral:
@@ -135,7 +136,7 @@ def parse_identifier(stream: "TokenStream") -> Identifier:
         if typ == TOKEN_IDENTIFIER:
             path.append(IdentifierPathElement(val))
         elif typ == TOKEN_IDENTINDEX:
-            path.append(IdentifierPathElement(int(val)))
+            path.append(IdentifierPathElement(to_int(val)))
         elif typ == TOKEN_LBRACKET:
             stream.next_token()
             path.append(parse_identifier(stream))

--- a/liquid/filter.py
+++ b/liquid/filter.py
@@ -18,6 +18,8 @@ from liquid.context import Undefined
 from liquid.exceptions import FilterArgumentError
 from liquid.exceptions import FilterValueError
 
+from liquid.limits import to_int
+
 if TYPE_CHECKING:  # pragma: no cover
     FilterT = Callable[..., Any]
     NumberT = Union[float, int]
@@ -118,7 +120,7 @@ def int_arg(val: Any, default: Optional[int] = None) -> int:
     """Return the ``val`` as an int or ``default`` if ``val`` can't be cast to an
     int."""
     try:
-        return int(val)
+        return to_int(val)
     except ValueError as err:
         if default is not None:
             return default
@@ -135,7 +137,7 @@ def num_arg(val: Any, default: Optional[NumberT] = None) -> NumberT:
 
     if isinstance(val, str):
         try:
-            return int(val)
+            return to_int(val)
         except ValueError:
             pass
 

--- a/liquid/limits.py
+++ b/liquid/limits.py
@@ -1,0 +1,33 @@
+"""System wide limits.
+
+Ideally these limits would be configurable from a liquid.Environment, but our
+template parser functions, filter decorators and expression objects don't have
+access to an Environment. Changing that would require significant refactoring
+resulting in too many breaking changes.
+"""
+
+import os
+from typing import Any
+
+from liquid.exceptions import LiquidValueError
+
+
+MAX_STR_INT = int(
+    os.environ.get(
+        "LIQUIDINTMAXSTRDIGITS",
+        os.environ.get("PYTHONINTMAXSTRDIGITS", "4300"),
+    )
+)
+
+
+def to_int(val: Any) -> int:
+    """Prevent DoS by very large str to int conversion.
+
+    See https://github.com/python/cpython/issues/95778
+    """
+    if isinstance(val, (str, bytes, bytearray)) and len(val) > MAX_STR_INT:
+        raise LiquidValueError(
+            f"integer string conversion limit ({MAX_STR_INT}) reached: "
+            f"value has {len(val)} digits"
+        )
+    return int(val)

--- a/liquid/parse.py
+++ b/liquid/parse.py
@@ -40,6 +40,7 @@ from liquid.lex import tokenize_boolean_expression
 from liquid.lex import tokenize_loop_expression
 from liquid.lex import tokenize_filtered_expression
 
+from liquid.limits import to_int
 from liquid.stream import TokenStream
 
 from liquid.exceptions import LiquidSyntaxError
@@ -299,7 +300,7 @@ def parse_string_literal(stream: TokenStream) -> expression.StringLiteral:
 
 def parse_integer_literal(stream: TokenStream) -> expression.IntegerLiteral:
     """Read an integer from the token stream."""
-    return expression.IntegerLiteral(value=int(stream.current.value))
+    return expression.IntegerLiteral(value=to_int(stream.current.value))
 
 
 def parse_float_literal(stream: TokenStream) -> expression.FloatLiteral:
@@ -353,7 +354,7 @@ def parse_identifier(stream: TokenStream) -> expression.Identifier:
             path.append(IdentifierPathElement(stream.current.value))
 
         elif stream.current.type == TOKEN_INTEGER:
-            path.append(IdentifierPathElement(int(stream.current.value)))
+            path.append(IdentifierPathElement(to_int(stream.current.value)))
 
         elif stream.current.type == TOKEN_LBRACKET:
             stream.next_token()  # Eat open bracket
@@ -363,9 +364,9 @@ def parse_identifier(stream: TokenStream) -> expression.Identifier:
             elif stream.current.type == TOKEN_NEGATIVE:
                 expect_peek(stream, TOKEN_INTEGER)
                 stream.next_token()
-                path.append(IdentifierPathElement(-int(stream.current.value)))
+                path.append(IdentifierPathElement(-to_int(stream.current.value)))
             elif stream.current.type == TOKEN_INTEGER:
-                path.append(IdentifierPathElement(int(stream.current.value)))
+                path.append(IdentifierPathElement(to_int(stream.current.value)))
 
             elif stream.current.type == TOKEN_IDENTIFIER:
                 # Recursive call to parse_identifier. If it's not a string or

--- a/tests/test_large_str_to_int.py
+++ b/tests/test_large_str_to_int.py
@@ -1,0 +1,30 @@
+# pylint: disable=missing-class-docstring missing-module-docstring
+import unittest
+
+from liquid import Template
+from liquid import Mode
+
+from liquid.exceptions import LiquidValueError
+from liquid.limits import MAX_STR_INT
+
+
+class StrToIntTestCase(unittest.TestCase):
+    def test_parse_long_integer_literal(self):
+        """Test that we honour the maximum str to int length on integer literals."""
+        Template("".join(["{{", "1" * MAX_STR_INT, " }}"]))
+
+        with self.assertRaises(LiquidValueError):
+            Template("".join(["{{", "1" * (MAX_STR_INT + 1), " }}"]))
+
+    def test_math_filter_long_string_literal(self):
+        """Test that we honour the maximum str to int length on string literals."""
+        template = Template("".join(["{{ '", "1" * MAX_STR_INT, "' | abs }}"]))
+        self.assertEqual(template.render(), "1" * MAX_STR_INT)
+
+        template = Template(
+            "".join(["{{ '", "1" * (MAX_STR_INT + 1), "' | abs }}"]),
+            tolerance=Mode.STRICT,
+        )
+
+        with self.assertRaises(LiquidValueError):
+            self.assertEqual(template.render(), "1" * (MAX_STR_INT + 1))


### PR DESCRIPTION
See [CVE-2020-10735](https://github.com/python/cpython/issues/95778).

The intention is that Python Liquid will continue to honour environment variables `LIQUIDINTMAXSTRDIGITS` or `PYTHONINTMAXSTRDIGITS` for setting a maximum number of digits when attempting to convert a string to an integer, even after patches have been released for various versions of Python. This is so Liquid's max can be set independently from Python's. 

Docs to follow.