### PR TITLE
fix: numbers are never falsy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Python Liquid Change Log
 ========================
 
+Version 1.4.5
+-------------
+
+**Hot fix**
+
+- Fixed a bug where boolean expressions and the default filter would treat ``0.0`` and 
+  ``decimal.Decimal("0")`` as ``False``. Python considers these values to be falsy,
+  Liquid does not. See `#74 <https://github.com/jg-rp/liquid/issues/74>`_.
+
 Version 1.4.4
 -------------
 

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 # pylint: disable=useless-import-alias,missing-module-docstring
 
-__version__ = "1.4.4"
+__version__ = "1.4.5"
 
 try:
     from markupsafe import escape as escape

--- a/liquid/builtin/filters/misc.py
+++ b/liquid/builtin/filters/misc.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime
+import decimal
 import functools
 
 from typing import Any
@@ -49,8 +50,8 @@ def default(obj: Any, default_: object = "", *, allow_false: bool = False) -> An
     if hasattr(obj, "__liquid__"):
         _obj = obj.__liquid__()
 
-    # Liquid zero is not falsy.
-    if isinstance(_obj, int) and not isinstance(_obj, bool):
+    # Liquid 0, 0.0, 0b0, 0X0, 0o0 and Decimal("0") are not falsy.
+    if not isinstance(obj, bool) and isinstance(obj, (int, float, decimal.Decimal)):
         return obj
 
     if allow_false is True and _obj is False:

--- a/liquid/golden/default_filter.py
+++ b/liquid/golden/default_filter.py
@@ -104,4 +104,9 @@ cases = [
         template=r'{{ 0 | default: "bar", allow_false: true }}',
         expect="0",
     ),
+    Case(
+        description="0.0 is not falsy",
+        template=r'{{ 0.0 | default: "bar" }}',
+        expect="0.0",
+    ),
 ]

--- a/liquid/golden/if_tag.py
+++ b/liquid/golden/if_tag.py
@@ -167,6 +167,11 @@ cases = [
         expect="Hello",
     ),
     Case(
+        description=("0.0 is truthy"),
+        template=(r"{% if 0.0 %}Hello{% else %}Goodbye{% endif %}"),
+        expect="Hello",
+    ),
+    Case(
         description=("one is not equal to true"),
         template=(r"{% if 1 == true %}Hello{% else %}Goodbye{% endif %}"),
         expect="Goodbye",

--- a/tests/filters/test_misc.py
+++ b/tests/filters/test_misc.py
@@ -1,6 +1,7 @@
 """Test miscellaneous filter functions."""
 # pylint: disable=too-many-public-methods,too-many-lines,missing-class-docstring
 import datetime
+import decimal
 import platform
 import unittest
 
@@ -276,6 +277,20 @@ class MiscFilterTestCase(unittest.TestCase):
                 args=["bar"],
                 kwargs={},
                 expect=0,
+            ),
+            Case(
+                description="0.0 is not false",
+                val=0.0,
+                args=["bar"],
+                kwargs={},
+                expect=0.0,
+            ),
+            Case(
+                description="Decimal('0') is not false",
+                val=decimal.Decimal("0"),
+                args=["bar"],
+                kwargs={},
+                expect=decimal.Decimal("0"),
             ),
             Case(
                 description="one is not false or true",

--- a/tests/test_evaluate_expression.py
+++ b/tests/test_evaluate_expression.py
@@ -1,23 +1,26 @@
 """Liquid expression evaluator test cases."""
 
 import unittest
-from typing import NamedTuple, Any, Mapping
+
+from decimal import Decimal
+
+from typing import Any
+from typing import Mapping
+from typing import NamedTuple
 
 from liquid.environment import Environment
 from liquid.context import Context
 from liquid.stream import TokenStream
-from liquid.lex import (
-    tokenize_filtered_expression,
-    tokenize_boolean_expression,
-    tokenize_loop_expression,
-    tokenize_assignment_expression,
-)
-from liquid.parse import (
-    parse_filtered_expression,
-    parse_boolean_expression,
-    parse_assignment_expression,
-    parse_loop_expression,
-)
+
+from liquid.lex import tokenize_filtered_expression
+from liquid.lex import tokenize_boolean_expression
+from liquid.lex import tokenize_loop_expression
+from liquid.lex import tokenize_assignment_expression
+
+from liquid.parse import parse_filtered_expression
+from liquid.parse import parse_boolean_expression
+from liquid.parse import parse_assignment_expression
+from liquid.parse import parse_loop_expression
 
 
 class Case(NamedTuple):
@@ -496,6 +499,12 @@ class LiquidStatementEvalTestCase(unittest.TestCase):
                 expect=True,
             ),
             Case(
+                description="0.0",
+                context={},
+                expression="0.0",
+                expect=True,
+            ),
+            Case(
                 description="one",
                 context={},
                 expression="1",
@@ -505,6 +514,24 @@ class LiquidStatementEvalTestCase(unittest.TestCase):
                 description="zero equals false",
                 context={},
                 expression="0 == false",
+                expect=False,
+            ),
+            Case(
+                description="zero equals true",
+                context={},
+                expression="0 == true",
+                expect=False,
+            ),
+            Case(
+                description="0.0 equals false",
+                context={},
+                expression="0.0 == false",
+                expect=False,
+            ),
+            Case(
+                description="0.0 equals true",
+                context={},
+                expression="0.0 == true",
                 expect=False,
             ),
             Case(
@@ -532,6 +559,12 @@ class LiquidStatementEvalTestCase(unittest.TestCase):
                 expect=False,
             ),
             Case(
+                description="0.0 is less than true",
+                context={},
+                expression="0.0 < true",
+                expect=False,
+            ),
+            Case(
                 description="one is not equal true",
                 context={},
                 expression="1 != true",
@@ -544,15 +577,51 @@ class LiquidStatementEvalTestCase(unittest.TestCase):
                 expect=True,
             ),
             Case(
+                description="0.0 is not equal false",
+                context={},
+                expression="0.0 != false",
+                expect=True,
+            ),
+            Case(
                 description="false is not equal zero",
                 context={},
                 expression="false != 0",
                 expect=True,
             ),
             Case(
+                description="false is not equal 0.0",
+                context={},
+                expression="false != 0.0",
+                expect=True,
+            ),
+            Case(
                 description="false is less than string",
                 context={},
                 expression="false < 'false'",
+                expect=False,
+            ),
+            Case(
+                description="decimal zero",
+                context={"n": Decimal("0")},
+                expression="n",
+                expect=True,
+            ),
+            Case(
+                description="decimal non-zero",
+                context={"n": Decimal("1")},
+                expression="n",
+                expect=True,
+            ),
+            Case(
+                description="decimal zero equals false",
+                context={"n": Decimal("0")},
+                expression="n == false",
+                expect=False,
+            ),
+            Case(
+                description="decimal zero equals true",
+                context={"n": Decimal("0")},
+                expression="n == true",
                 expect=False,
             ),
         ]


### PR DESCRIPTION
This pull requests fixes a bug where boolean expressions and the `default` filter would incorrectly consider some numbers to be falsy.

Unlike Python, Liquid `0`, `0.0`, `0b0`, `0X0`, `0o0` and `Decimal("0")` are not falsy. See #74.