### PR TITLE
fix: local namespace limit size and unhashable types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Python Liquid Change Log
 ========================
 
+Version 1.4.7
+-------------
+
+**Hot fix**
+
+- Fixed a bug where use of a `local namespace limit <https://jg-rp.github.io/liquid/guides/resource-limits#local-namespace-limit>`_
+  would raise a `TypeError` when unhashable types were found in a render context's local
+  namespace. . See `#79 <https://github.com/jg-rp/liquid/issues/79>`_.
+
 Version 1.4.6
 -------------
 

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 # pylint: disable=useless-import-alias,missing-module-docstring
 
-__version__ = "1.4.6"
+__version__ = "1.4.7"
 
 try:
     from markupsafe import escape as escape

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -253,7 +253,7 @@ class LocalNamespaceLimitTestCase(unittest.TestCase):
 
     def test_copied_context_carries_parent_length(self):
         """Test that copied render context object cary the length of their parent
-        context's locale namespace."""
+        context's local namespace."""
 
         class MockEnv(Environment):
             local_namespace_limit = 5
@@ -277,6 +277,20 @@ class LocalNamespaceLimitTestCase(unittest.TestCase):
 
         with self.assertRaises(LocalNamespaceLimitError):
             template.render()
+
+    def test_sizeof_local_namespace_with_unhashable_values(self):
+        """Test that we can calculate the size of a local namespace when it contains
+        unhashable objects."""
+
+        class MockEnv(Environment):
+            local_namespace_limit = 200
+
+        env = MockEnv()
+        env.from_string("{% assign foo = bar %}").render(bar=[1, 2, 3, 4])
+
+        env.from_string(
+            '{% assign beatles = "John, Paul, George, Ringo" | split: ", " %}'
+        ).render()
 
 
 class OutputStreamLimitTestCase(unittest.TestCase):


### PR DESCRIPTION
This pull request fixes #79 by not building a `set` from a render context's local namespace values when calculating its size. I'm not sure what I was thinking there 😞.

I also recognise that using `sys.getsizeof()` to calculate the "size" of a render context namespace is not always appropriate. `Context._get_size_of_locals()` has been renamed to `Context.get_size_of_locals()` and is now considered part of the public API. See the comments on issue #79 for an example of customizing the local namespace limit calculation by overriding `Context.get_size_of_locals()`.