### PR TITLE
Extra tags and filters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,14 @@ Version 1.5.0 (unreleased)
 
 **Features**
 
-- Added a non-standard ``if`` tag implementation that supports a logical ``not``
-  operator and grouping terms with parentheses. For example:
+The following non-standard tags and filters are reimplementations of those found in the
+`Python Liquid Extra project <https://github.com/jg-rp/liquid-extra>`_, which is now
+receiving bugfix updates only. Unlike standard tags and filters, which are registered
+for you automatically, extra tags and filters must be explicitly registered with an
+``Environment``. See https://jg-rp.github.io/liquid/extra/introduction.
+
+- Added an ``if`` tag that supports a logical ``not`` operator and grouping
+  terms with parentheses. For example:
 
   ``{% if not product.available %}``
 
@@ -26,6 +32,13 @@ Version 1.5.0 (unreleased)
 
 - Optionally support extended boolean expressions (as described above) within inline
   conditional expressions (also described above.)
+- Added ``macro`` and ``call`` tags that define parameterized Liquid
+  snippets for reuse.
+- Added the ``with`` tag that extends the local namespace with block scoped variables.
+- Added the ``json`` filter.
+- Added the ``index`` filter.
+- Added the ``script_tag`` filter.
+- Added the ``stylesheet_tag`` filter.
 
 Version 1.4.7
 -------------

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 # pylint: disable=useless-import-alias,missing-module-docstring
 
-__version__ = "1.4.7"
+__version__ = "1.5.0"
 
 try:
     from markupsafe import escape as escape

--- a/liquid/expressions/__init__.py
+++ b/liquid/expressions/__init__.py
@@ -3,6 +3,9 @@
 from liquid.expressions.common import Token
 from liquid.expressions.stream import TokenStream
 
+from liquid.expressions.arguments import parse_call_arguments
+from liquid.expressions.arguments import parse_keyword_arguments
+from liquid.expressions.arguments import parse_macro_arguments
 from liquid.expressions.boolean.parse import parse as parse_boolean_expression
 from liquid.expressions.boolean.parse import (
     parse_with_parens as parse_boolean_expression_with_parens,
@@ -16,6 +19,9 @@ from liquid.expressions.loop.parse import parse as parse_loop_expression
 
 
 __all__ = (
+    "parse_call_arguments",
+    "parse_keyword_arguments",
+    "parse_macro_arguments",
     "parse_boolean_expression",
     "parse_boolean_expression_with_parens",
     "parse_conditional_expression",

--- a/liquid/expressions/arguments/__init__.py
+++ b/liquid/expressions/arguments/__init__.py
@@ -8,4 +8,5 @@ __all__ = (
     "parse_call_arguments",
     "parse_keyword_arguments",
     "parse_macro_arguments",
+    "tokenize",
 )

--- a/liquid/expressions/arguments/__init__.py
+++ b/liquid/expressions/arguments/__init__.py
@@ -1,0 +1,11 @@
+# pylint: disable=missing-module-docstring
+from .lex import tokenize
+from .parse import parse_call_arguments
+from .parse import parse_keyword_arguments
+from .parse import parse_macro_arguments
+
+__all__ = (
+    "parse_call_arguments",
+    "parse_keyword_arguments",
+    "parse_macro_arguments",
+)

--- a/liquid/expressions/arguments/lex.py
+++ b/liquid/expressions/arguments/lex.py
@@ -1,0 +1,106 @@
+"""Tokenize include expressions."""
+import re
+from typing import Iterator
+
+from liquid.expressions.common import Token
+from liquid.expressions.common import GROUP_QUOTED
+from liquid.expressions.common import GROUP_IDENTINDEX
+from liquid.expressions.common import GROUP_IDENTQUOTED
+from liquid.expressions.common import IDENTIFIER_PATTERN
+from liquid.expressions.common import IDENTSTRING_PATTERN
+from liquid.expressions.common import IDENTINDEX_PATTERN
+from liquid.expressions.common import STRING_PATTERN
+
+from liquid.token import TOKEN_RANGE
+from liquid.token import TOKEN_FLOAT
+from liquid.token import TOKEN_INTEGER
+from liquid.token import TOKEN_TRUE
+from liquid.token import TOKEN_FALSE
+from liquid.token import TOKEN_NIL
+from liquid.token import TOKEN_NULL
+from liquid.token import TOKEN_EMPTY
+from liquid.token import TOKEN_BLANK
+from liquid.token import TOKEN_IDENTIFIER
+from liquid.token import TOKEN_STRING
+from liquid.token import TOKEN_ILLEGAL
+from liquid.token import TOKEN_SKIP
+from liquid.token import TOKEN_NEWLINE
+from liquid.token import TOKEN_LBRACKET
+from liquid.token import TOKEN_RBRACKET
+from liquid.token import TOKEN_LPAREN
+from liquid.token import TOKEN_RPAREN
+from liquid.token import TOKEN_COLON
+from liquid.token import TOKEN_COMMA
+from liquid.token import TOKEN_IDENTSTRING
+from liquid.token import TOKEN_IDENTINDEX
+from liquid.token import TOKEN_DOT
+
+from liquid.exceptions import LiquidSyntaxError
+
+
+token_rules = (
+    (TOKEN_IDENTINDEX, IDENTINDEX_PATTERN),
+    (TOKEN_IDENTSTRING, IDENTSTRING_PATTERN),
+    (TOKEN_STRING, STRING_PATTERN),
+    (TOKEN_RANGE, r"\.\."),
+    (TOKEN_FLOAT, r"-?\d+\.(?!\.)\d*"),
+    (TOKEN_INTEGER, r"-?\d+\b"),
+    (TOKEN_DOT, r"\."),
+    (TOKEN_IDENTIFIER, IDENTIFIER_PATTERN),
+    (TOKEN_LPAREN, r"\("),
+    (TOKEN_RPAREN, r"\)"),
+    (TOKEN_LBRACKET, r"\["),
+    (TOKEN_RBRACKET, r"]"),
+    (TOKEN_COMMA, r","),
+    (TOKEN_COLON, r":"),
+    (TOKEN_NEWLINE, r"\n"),
+    (TOKEN_SKIP, r"[ \t\r]+"),
+    (TOKEN_ILLEGAL, r"."),
+)
+
+keywords = frozenset(
+    [
+        TOKEN_TRUE,
+        TOKEN_FALSE,
+        TOKEN_NIL,
+        TOKEN_NULL,
+        TOKEN_EMPTY,
+        TOKEN_BLANK,
+    ]
+)
+
+OUTPUT_RE = re.compile(
+    "|".join(f"(?P<{name}>{pattern})" for name, pattern in token_rules),
+    re.DOTALL,
+)
+
+
+def tokenize(source: str, linenum: int = 1) -> Iterator[Token]:
+    """Yield tokens from an output expression."""
+    _keywords = keywords
+    for match in OUTPUT_RE.finditer(source):
+        kind = match.lastgroup
+        assert kind is not None
+
+        value = match.group()
+        newlines = value.count("\n")
+
+        if kind == TOKEN_IDENTIFIER and value in _keywords:
+            kind = value
+        elif kind == TOKEN_IDENTINDEX:
+            value = match.group(GROUP_IDENTINDEX)
+        elif kind == TOKEN_IDENTSTRING:
+            kind = TOKEN_IDENTIFIER
+            value = match.group(GROUP_IDENTQUOTED)
+        elif kind == TOKEN_STRING:
+            value = match.group(GROUP_QUOTED)
+        elif kind == TOKEN_NEWLINE:
+            linenum += 1
+            continue
+        elif kind == TOKEN_SKIP:
+            continue
+        elif kind == TOKEN_ILLEGAL:
+            raise LiquidSyntaxError(f"unexpected {value!r}", linenum=linenum)
+
+        linenum += newlines
+        yield (linenum, kind, value)

--- a/liquid/expressions/arguments/lex.py
+++ b/liquid/expressions/arguments/lex.py
@@ -34,6 +34,7 @@ from liquid.token import TOKEN_COMMA
 from liquid.token import TOKEN_IDENTSTRING
 from liquid.token import TOKEN_IDENTINDEX
 from liquid.token import TOKEN_DOT
+from liquid.token import TOKEN_EQUALS
 
 from liquid.exceptions import LiquidSyntaxError
 
@@ -53,6 +54,7 @@ token_rules = (
     (TOKEN_RBRACKET, r"]"),
     (TOKEN_COMMA, r","),
     (TOKEN_COLON, r":"),
+    (TOKEN_EQUALS, r"="),
     (TOKEN_NEWLINE, r"\n"),
     (TOKEN_SKIP, r"[ \t\r]+"),
     (TOKEN_ILLEGAL, r"."),

--- a/liquid/expressions/arguments/parse.py
+++ b/liquid/expressions/arguments/parse.py
@@ -1,0 +1,124 @@
+"""Generic argument list parsers."""
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from liquid.expression import Expression
+from liquid.expression import NIL
+
+from liquid.expressions.common import parse_unchained_identifier
+from liquid.expressions.arguments.lex import tokenize
+from liquid.expressions.filtered.parse import parse_obj
+from liquid.expressions.stream import TokenStream
+
+from liquid.token import TOKEN_COLON
+from liquid.token import TOKEN_COMMA
+from liquid.token import TOKEN_EOF
+
+
+Argument = Tuple[Optional[str], Expression]
+
+
+def make_parse_arguments(
+    func: Callable[[TokenStream, str], Argument],
+    separator_token: str = TOKEN_COLON,
+) -> Callable[[TokenStream], List[Argument]]:
+    """Return an argument list parser using the given function to parse
+    each argument."""
+
+    def _parse_arguments(stream: TokenStream) -> List[Argument]:
+        """Parse arguments from a stream of tokens until EOF."""
+        args: List[Argument] = []
+        # Leading commas are OK
+        if stream.current[1] == TOKEN_COMMA:
+            next(stream)
+
+        while stream.current[1] != TOKEN_EOF:
+            args.append(func(stream, separator_token))
+            next(stream)
+            # Catch missing comma
+            if stream.current[1] != TOKEN_EOF:
+                stream.expect(TOKEN_COMMA)
+            # Eat comma. Trailing commas are OK
+            if stream.current[1] == TOKEN_COMMA:
+                next(stream)
+
+        return args
+
+    return _parse_arguments
+
+
+def parse_argument(stream: TokenStream, separator_token: str) -> Argument:
+    """Parse a single keyword argument from a stream of tokens."""
+    key = str(parse_unchained_identifier(stream))
+    next(stream)
+    stream.expect(separator_token)
+    next(stream)  # Eat separator
+    return key, parse_obj(stream)
+
+
+parse_colon_separated_arguments = make_parse_arguments(parse_argument, TOKEN_COLON)
+parse_equals_separated_arguments = make_parse_arguments(parse_argument, "=")
+
+
+def parse_keyword_arguments(expr: str, linenum: int = 1) -> Dict[str, Expression]:
+    """Parse keyword or named arguments from a Liquid expression string.
+
+    Each key/value pair is assumed to be separated by a comma. Leading and
+    trailing commas are OK.
+
+    If the same key/name appears multiple times, the last occurrence in the
+    argument "list" will take priority.
+
+    Values can be string, integer, float, true, false or nil literals, an
+    identifier or a range expression. An identifier value could be chained
+    using a mixture of dot and bracket notation."""
+    return dict(parse_colon_separated_arguments(TokenStream(tokenize(expr, linenum))))
+
+
+def parse_macro_argument(stream: TokenStream, separator_token: str) -> Argument:
+    """Parse either a positional or keyword argument.
+
+    If the separator token appears after an identifier, the argument is a keyword
+    argument. Otherwise it is positional, with an expression of NIL.
+    """
+    key = str(parse_unchained_identifier(stream))
+    next(stream)
+    if stream.current[1] == separator_token:
+        # A keyword argument
+        next(stream)  # Eat separator
+        val = parse_obj(stream)
+    else:
+        # A positional argument
+        val = NIL
+    return key, val
+
+
+def parse_call_argument(stream: TokenStream, separator_token: str) -> Argument:
+    """Parse an argument value that could be preceded by a name."""
+    if stream.peek[1] == separator_token:
+        # A keyword argument
+        key: Optional[str] = str(parse_unchained_identifier(stream))
+        next(stream)
+        next(stream)  # Eat separator
+    else:
+        # A positional argument
+        key = None
+
+    return key, parse_obj(stream)
+
+
+_parse_macro_arguments = make_parse_arguments(parse_macro_argument, TOKEN_COLON)
+_parse_call_arguments = make_parse_arguments(parse_call_argument, TOKEN_COLON)
+
+
+def parse_macro_arguments(expr: str, linenum: int = 1) -> List[Argument]:
+    """Parse a sequence of argument names, possibly with default values."""
+    return _parse_macro_arguments(TokenStream(tokenize(expr, linenum)))
+
+
+def parse_call_arguments(expr: str, linenum: int = 1) -> List[Argument]:
+    """Parse a sequence of positional and/or keyword arguments."""
+    return _parse_call_arguments(TokenStream(tokenize(expr, linenum)))

--- a/liquid/expressions/arguments/parse.py
+++ b/liquid/expressions/arguments/parse.py
@@ -1,4 +1,5 @@
 """Generic argument list parsers."""
+from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
@@ -16,9 +17,10 @@ from liquid.expressions.stream import TokenStream
 from liquid.token import TOKEN_COLON
 from liquid.token import TOKEN_COMMA
 from liquid.token import TOKEN_EOF
+from liquid.token import TOKEN_EQUALS
 
 
-Argument = Tuple[Optional[str], Expression]
+Argument = Tuple[Any, Expression]
 
 
 def make_parse_arguments(
@@ -60,7 +62,7 @@ def parse_argument(stream: TokenStream, separator_token: str) -> Argument:
 
 
 parse_colon_separated_arguments = make_parse_arguments(parse_argument, TOKEN_COLON)
-parse_equals_separated_arguments = make_parse_arguments(parse_argument, "=")
+parse_equals_separated_arguments = make_parse_arguments(parse_argument, TOKEN_EQUALS)
 
 
 def parse_keyword_arguments(expr: str, linenum: int = 1) -> Dict[str, Expression]:
@@ -85,8 +87,8 @@ def parse_macro_argument(stream: TokenStream, separator_token: str) -> Argument:
     argument. Otherwise it is positional, with an expression of NIL.
     """
     key = str(parse_unchained_identifier(stream))
-    next(stream)
-    if stream.current[1] == separator_token:
+    if stream.peek[1] == separator_token:
+        next(stream)
         # A keyword argument
         next(stream)  # Eat separator
         val = parse_obj(stream)

--- a/liquid/expressions/arguments/parse.py
+++ b/liquid/expressions/arguments/parse.py
@@ -9,6 +9,7 @@ from typing import Tuple
 from liquid.expression import Expression
 from liquid.expression import NIL
 
+from liquid.expressions.common import parse_string_literal
 from liquid.expressions.common import parse_unchained_identifier
 from liquid.expressions.arguments.lex import tokenize
 from liquid.expressions.filtered.parse import parse_obj
@@ -116,11 +117,17 @@ _parse_macro_arguments = make_parse_arguments(parse_macro_argument, TOKEN_COLON)
 _parse_call_arguments = make_parse_arguments(parse_call_argument, TOKEN_COLON)
 
 
-def parse_macro_arguments(expr: str, linenum: int = 1) -> List[Argument]:
+def parse_macro_arguments(expr: str, linenum: int = 1) -> Tuple[str, List[Argument]]:
     """Parse a sequence of argument names, possibly with default values."""
-    return _parse_macro_arguments(TokenStream(tokenize(expr, linenum)))
+    stream = TokenStream(tokenize(expr, linenum))
+    name = parse_string_literal(stream).value
+    next(stream)
+    return name, _parse_macro_arguments(stream)
 
 
-def parse_call_arguments(expr: str, linenum: int = 1) -> List[Argument]:
+def parse_call_arguments(expr: str, linenum: int = 1) -> Tuple[str, List[Argument]]:
     """Parse a sequence of positional and/or keyword arguments."""
-    return _parse_call_arguments(TokenStream(tokenize(expr, linenum)))
+    stream = TokenStream(tokenize(expr, linenum))
+    name = parse_string_literal(stream).value
+    next(stream)
+    return name, _parse_call_arguments(stream)

--- a/liquid/extra/__init__.py
+++ b/liquid/extra/__init__.py
@@ -2,6 +2,12 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
+from .filters import index
+from .filters import JSON
+from .filters import script_tag
+from .filters import stylesheet_tag
+
+from .tags import CallTag
 from .tags import IfNotTag
 from .tags import InlineIfAssignTag
 from .tags import InlineIfAssignTagWithParens
@@ -9,11 +15,19 @@ from .tags import InlineIfEchoTag
 from .tags import InlineIfEchoTagWithParens
 from .tags import InlineIfStatement
 from .tags import InlineIfStatementWithParens
+from .tags import MacroTag
+from .tags import WithTag
 
-if TYPE_CHECKING:
+
+if TYPE_CHECKING:  # pragma: no cover
     from liquid import Environment
 
 __all__ = (
+    "index",
+    "JSON",
+    "script_tag",
+    "stylesheet_tag",
+    "CallTag",
     "IfNotTag",
     "InlineIfAssignTag",
     "InlineIfAssignTagWithParens",
@@ -21,12 +35,17 @@ __all__ = (
     "InlineIfEchoTagWithParens",
     "InlineIfStatement",
     "InlineIfStatementWithParens",
-    "register_inline_if_expressions",
-    "register_inline_if_expressions_with_parens",
+    "MacroTag",
+    "WithTag",
+    "add_inline_expressions",
+    "add_extended_inline_expressions",
+    "add_macros",
+    "add_tags",
+    "add_tags_and_filters",
 )
 
 
-def register_inline_if_expressions(env: Environment) -> None:
+def add_inline_expressions(env: Environment) -> None:
     """Replace standard implementations of the output statement,
     `echo` tag and `assign` tag with ones that support inline `if`
     expressions."""
@@ -35,10 +54,39 @@ def register_inline_if_expressions(env: Environment) -> None:
     env.add_tag(InlineIfStatement)
 
 
-def register_inline_if_expressions_with_parens(env: Environment) -> None:
+def add_extended_inline_expressions(env: Environment) -> None:
     """Replace standard implementations of the output statement,
     `echo` tag and `assign` tag with ones that support inline `if`
     expressions."""
     env.add_tag(InlineIfAssignTagWithParens)
     env.add_tag(InlineIfEchoTagWithParens)
     env.add_tag(InlineIfStatementWithParens)
+
+
+def add_macros(env: Environment) -> None:
+    """Register both the `macro` and `call` tags with an environment."""
+    env.add_tag(CallTag)
+    env.add_tag(MacroTag)
+
+
+def add_tags(env: Environment) -> None:  # pragma: no cover
+    """Register all extra tags with an environment."""
+    env.add_tag(IfNotTag)
+    env.add_tag(WithTag)
+    add_macros(env)
+    add_extended_inline_expressions(env)
+
+
+def add_filters(env: Environment) -> None:
+    """Register all extra filters with an environment with their default
+    and options."""
+    env.add_filter("index", index)
+    env.add_filter("json", JSON())
+    env.add_filter("script_tag", script_tag)
+    env.add_filter("stylesheet_tag", stylesheet_tag)
+
+
+def add_tags_and_filters(env: Environment) -> None:  # pragma: no cover
+    """Register all extra tags and filters with an environment."""
+    add_tags(env)
+    add_filters(env)

--- a/liquid/extra/filters/__init__.py
+++ b/liquid/extra/filters/__init__.py
@@ -1,0 +1,13 @@
+# pylint: disable=missing-module-docstring
+from .array import index
+from .html import script_tag
+from .html import stylesheet_tag
+from ._json import JSON
+
+
+__all__ = (
+    "index",
+    "JSON",
+    "script_tag",
+    "stylesheet_tag",
+)

--- a/liquid/extra/filters/_json.py
+++ b/liquid/extra/filters/_json.py
@@ -1,0 +1,36 @@
+"""A JSON filter."""
+import json
+
+from typing import Any
+from typing import Callable
+from typing import Optional
+
+from liquid.filter import int_arg
+from liquid.filter import liquid_filter
+
+
+class JSON:  # pylint: disable=too-few-public-methods
+    """Serialize an object to a JSON formatted string.
+
+    :param default: A function passed to `json.dumps`. This function is called
+        in the event that the JSONEncoder does not know how to serialize an
+        object. Defaults to ``None``.
+    :type default: Optional[Callable[[Any], Any]]
+    :param strip_tags: If ``True``, HTML tags will be removed from the resulting
+        JSON formatted string. Defaults to ``True``.
+    :type strip_tags: bool
+    """
+
+    name = "json"
+
+    def __init__(self, default: Optional[Callable[[Any], Any]] = None):
+        self.default = default
+
+    @liquid_filter
+    def __call__(
+        self,
+        obj: object,
+        indent: Optional[object] = None,
+    ) -> str:
+        indent = int_arg(indent) if indent else None
+        return json.dumps(obj, default=self.default, indent=indent)

--- a/liquid/extra/filters/array.py
+++ b/liquid/extra/filters/array.py
@@ -1,12 +1,11 @@
 """Extra array filters."""
 from typing import Sequence
-
 from liquid.filter import array_filter
 
 
 @array_filter
 def index(left: Sequence[object], obj: object) -> object:
-    """Return the first zero-based index of an item in an array, or None if
+    """Return the zero-based index of an item in an array, or None if
     the items is not in the array.
     """
     try:

--- a/liquid/extra/filters/array.py
+++ b/liquid/extra/filters/array.py
@@ -1,0 +1,15 @@
+"""Extra array filters."""
+from typing import Sequence
+
+from liquid.filter import array_filter
+
+
+@array_filter
+def index(left: Sequence[object], obj: object) -> object:
+    """Return the first zero-based index of an item in an array, or None if
+    the items is not in the array.
+    """
+    try:
+        return left.index(obj)
+    except ValueError:
+        return None

--- a/liquid/extra/filters/html.py
+++ b/liquid/extra/filters/html.py
@@ -1,0 +1,27 @@
+"""Extra HTML filters."""
+import html
+
+from liquid import Markup
+from liquid.filter import string_filter
+from liquid.filter import with_environment
+from liquid import Environment
+
+
+@string_filter
+@with_environment
+def stylesheet_tag(url: str, *, environment: Environment) -> str:
+    """Wrap a URL in an HTML stylesheet tag."""
+    tag = '<link href="{}" rel="stylesheet" type="text/css" media="all" />'
+    if environment.autoescape:
+        return Markup(tag).format(str(url))
+    return tag.format(html.escape(url))
+
+
+@string_filter
+@with_environment
+def script_tag(url: str, *, environment: Environment) -> str:
+    """Wrap a URL in an HTML script tag."""
+    tag = '<script src="{}" type="text/javascript"></script>'
+    if environment.autoescape:
+        return Markup(tag).format(str(url))
+    return tag.format(html.escape(url))

--- a/liquid/extra/tags/__init__.py
+++ b/liquid/extra/tags/__init__.py
@@ -6,8 +6,12 @@ from .if_expressions import InlineIfEchoTag
 from .if_expressions import InlineIfEchoTagWithParens
 from .if_expressions import InlineIfStatement
 from .if_expressions import InlineIfStatementWithParens
+from .macro import MacroTag
+from .macro import CallTag
 
 __all__ = (
+    "CallTag",
+    "MacroTag",
     "IfNotTag",
     "InlineIfAssignTag",
     "InlineIfAssignTagWithParens",

--- a/liquid/extra/tags/__init__.py
+++ b/liquid/extra/tags/__init__.py
@@ -8,6 +8,7 @@ from .if_expressions import InlineIfStatement
 from .if_expressions import InlineIfStatementWithParens
 from .macro import MacroTag
 from .macro import CallTag
+from ._with import WithTag
 
 __all__ = (
     "CallTag",
@@ -19,4 +20,5 @@ __all__ = (
     "InlineIfEchoTagWithParens",
     "InlineIfStatement",
     "InlineIfStatementWithParens",
+    "WithTag",
 )

--- a/liquid/extra/tags/_with.py
+++ b/liquid/extra/tags/_with.py
@@ -1,0 +1,98 @@
+"""Node and tag definitions for `with`."""
+# pylint: disable=missing-class-docstring
+from __future__ import annotations
+
+import sys
+
+from typing import TYPE_CHECKING
+from typing import Dict
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+from typing import TextIO
+
+from liquid.ast import ChildNode
+from liquid.ast import Node
+from liquid.ast import BlockNode
+
+from liquid.context import Context
+from liquid.expression import Expression
+from liquid.expressions import parse_keyword_arguments
+
+from liquid.parse import expect
+from liquid.parse import get_parser
+
+from liquid.stream import TokenStream
+from liquid.tag import Tag
+
+from liquid.token import Token
+from liquid.token import TOKEN_TAG
+from liquid.token import TOKEN_EXPRESSION
+from liquid.token import TOKEN_EOF
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from liquid import Environment
+
+TAG_WITH = sys.intern("with")
+TAG_ENDWITH = sys.intern("endwith")
+
+
+class WithKeywordArg(NamedTuple):
+    name: str
+    expr: Expression
+
+
+class WithNode(Node):
+    def __init__(self, tok: Token, args: Dict[str, Expression], block: BlockNode):
+        self.tok = tok
+        self.args = args
+        self.block = block
+
+    def render_to_output(self, context: Context, buffer: TextIO) -> Optional[bool]:
+        namespace = {k: v.evaluate(context) for k, v in self.args.items()}
+
+        with context.extend(namespace):
+            return self.block.render(context, buffer)
+
+    async def render_to_output_async(
+        self, context: Context, buffer: TextIO
+    ) -> Optional[bool]:
+        namespace = {k: await v.evaluate_async(context) for k, v in self.args.items()}
+        with context.extend(namespace):
+            return await self.block.render_async(context, buffer)
+
+    def children(self) -> List[ChildNode]:
+        return [
+            ChildNode(
+                linenum=self.tok.linenum, node=self.block, block_scope=list(self.args)
+            ),
+            *[
+                ChildNode(linenum=self.tok.linenum, expression=expr)
+                for expr in self.args.values()
+            ],
+        ]
+
+
+class WithTag(Tag):
+    name = TAG_WITH
+    end = TAG_ENDWITH
+
+    def __init__(self, env: Environment):
+        super().__init__(env)
+        self.parser = get_parser(self.env)
+
+    def parse(self, stream: TokenStream) -> Node:
+        expect(stream, TOKEN_TAG, value=TAG_WITH)
+        tok = next(stream)
+
+        # Parse keyword arguments
+        expect(stream, TOKEN_EXPRESSION)
+        args = parse_keyword_arguments(stream.current.value)
+        stream.next_token()
+
+        # Parse the block
+        block = self.parser.parse_block(stream, (TAG_ENDWITH, TOKEN_EOF))
+        expect(stream, TOKEN_TAG, value=TAG_ENDWITH)
+
+        return WithNode(tok=tok, args=args, block=block)

--- a/liquid/extra/tags/macro.py
+++ b/liquid/extra/tags/macro.py
@@ -1,0 +1,437 @@
+"""Node and tag definitions for `macro` and `call`."""
+from __future__ import annotations
+
+import functools
+import itertools
+import sys
+
+from typing import Optional
+from typing import Tuple
+from typing import Dict
+from typing import List
+from typing import NamedTuple
+from typing import TextIO
+from typing import Union
+from typing import TYPE_CHECKING
+
+from liquid.ast import ChildNode
+from liquid.ast import Node
+from liquid.ast import BlockNode
+
+from liquid.context import is_undefined
+from liquid.context import Undefined
+from liquid.context import Context
+from liquid.context import ReadOnlyChainMap
+
+from liquid.expression import Expression
+from liquid.expression import NIL
+from liquid.exceptions import LiquidSyntaxError
+
+from liquid.lex import STRING_PATTERN
+from liquid.lex import _tokenize
+from liquid.lex import _compile_rules
+
+from liquid.parse import expect
+from liquid.parse import get_parser
+from liquid.parse import parse_expression
+from liquid.parse import parse_string_literal
+from liquid.parse import parse_unchained_identifier
+
+from liquid.stream import TokenStream
+from liquid.tag import Tag
+
+from liquid.builtin.tags.include_tag import TAG_INCLUDE
+
+from liquid.token import Token
+from liquid.token import TOKEN_TAG
+from liquid.token import TOKEN_EXPRESSION
+from liquid.token import TOKEN_IDENTIFIER
+from liquid.token import TOKEN_EOF
+from liquid.token import TOKEN_STRING
+from liquid.token import TOKEN_ILLEGAL
+from liquid.token import TOKEN_INTEGER
+from liquid.token import TOKEN_FLOAT
+from liquid.token import TOKEN_EMPTY
+from liquid.token import TOKEN_NIL
+from liquid.token import TOKEN_NULL
+from liquid.token import TOKEN_BLANK
+from liquid.token import TOKEN_NEGATIVE
+from liquid.token import TOKEN_TRUE
+from liquid.token import TOKEN_FALSE
+from liquid.token import TOKEN_COLON
+from liquid.token import TOKEN_COMMA
+from liquid.token import TOKEN_DOT
+from liquid.token import TOKEN_LBRACKET
+from liquid.token import TOKEN_RBRACKET
+
+if TYPE_CHECKING:  # pragma: no cover
+    from liquid import Environment
+
+
+TAG_MACRO = sys.intern("macro")
+TAG_ENDMACRO = sys.intern("endmacro")
+TAG_CALL = sys.intern("call")
+
+
+class CallKeywordArg(NamedTuple):
+    """A named argument as used in a `call` expression."""
+
+    name: str
+    expr: Expression
+
+
+class MacroArg(NamedTuple):
+    """A macro argument with an optional default value."""
+
+    name: str
+    default: Expression = NIL
+
+
+class Macro(NamedTuple):
+    """A macro block and its arguments."""
+
+    args: List[MacroArg]
+    block: BlockNode
+
+
+macro_expression_rules = (
+    (TOKEN_FLOAT, r"\d+\.\d*"),
+    (TOKEN_INTEGER, r"\d+"),
+    (TOKEN_NEGATIVE, r"-"),
+    (TOKEN_STRING, STRING_PATTERN),
+    (TOKEN_IDENTIFIER, r"\w[a-zA-Z0-9_\-?]*"),
+    (TOKEN_DOT, r"\."),
+    (TOKEN_COMMA, r","),
+    (TOKEN_LBRACKET, r"\["),
+    (TOKEN_RBRACKET, r"]"),
+    (TOKEN_COLON, r":"),
+    ("NEWLINE", r"\n"),
+    ("SKIP", r"[ \t]+"),
+    (TOKEN_ILLEGAL, r"."),
+)
+
+macro_expression_keywords = frozenset(
+    [
+        TOKEN_TRUE,
+        TOKEN_FALSE,
+        TOKEN_NIL,
+        TOKEN_NULL,
+        TOKEN_EMPTY,
+        TOKEN_BLANK,
+    ]
+)
+
+tokenize_macro_expression = functools.partial(
+    _tokenize,
+    rules=_compile_rules(macro_expression_rules),
+    keywords=macro_expression_keywords,
+)
+
+
+class MacroNode(Node):
+    """Parse tree node representing a macro."""
+
+    __slots__ = ("tok", "name", "args", "block")
+
+    def __init__(
+        self,
+        tok: Token,
+        name: str,
+        args: List[MacroArg],
+        block: BlockNode,
+    ):
+        self.tok = tok
+        self.name = name
+        self.args = args
+        self.block = block
+
+    def __str__(self) -> str:  # pragma: no cover
+        args: List[str] = []
+        for arg, default in self.args:
+            if default is not NIL:
+                args.append(f"{arg}={default}")
+            else:
+                args.append(arg)
+        return f"def {self.name}({', '.join(args)}) {{ {self.block} }}"
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"MacroNode(tok={self.tok}, name={self.name}, block='{self.block}')"
+
+    def render_to_output(self, context: Context, buffer: TextIO) -> Optional[bool]:
+        if "macros" not in context.tag_namespace:
+            context.tag_namespace["macros"] = {}
+
+        context.tag_namespace["macros"][self.name] = Macro(self.args, self.block)
+        return False
+
+    def children(self) -> List[ChildNode]:
+        # We don't currently have a good, generic way to model the `macro`/`call`
+        # relationship for static analysis. When a macro is called, arguments without
+        # defaults are expected to be `Undefined`.
+        _children = [
+            ChildNode(
+                linenum=self.tok.linenum,
+                node=self.block,
+                block_scope=[arg.name for arg in self.args],
+            )
+        ]
+        for _, expr in self.args:
+            if expr != NIL:
+                _children.append(ChildNode(linenum=self.tok.linenum, expression=expr))
+        return _children
+
+
+class CallNode(Node):
+    """Parse tree node representing a call to a macro."""
+
+    __slots__ = ("tok", "name", "args", "kwargs")
+
+    def __init__(
+        self,
+        tok: Token,
+        name: str,
+        args: List[Expression],
+        kwargs: List[CallKeywordArg],
+    ):
+        self.tok = tok
+        self.name = name
+        self.args = args
+        self.kwargs = kwargs
+
+    def __str__(self) -> str:  # pragma: no cover
+        args = [str(expr) for expr in self.args]
+        for name, expr in self.kwargs:
+            args.append(f"{name}: {expr}")
+        return f"{self.name}({', '.join(args)})"
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"CallNode(tok={self.tok}, name={self.name})"
+
+    def _make_context(self, context: Context, macro: Macro) -> Context:
+        args = dict(macro.args)
+        macro_names = [arg.name for arg in macro.args]
+
+        # Bind positional arguments to names. If there are more positional arguments
+        # than names defined in the macro, they'll be stored in `excess_args`.
+        excess_args: List[Expression] = []
+        for name, expr in itertools.zip_longest(macro_names, self.args, fillvalue=NIL):
+            if name == NIL:
+                excess_args.append(expr)
+                continue
+            if expr == NIL:
+                break
+            assert isinstance(name, str)
+            args[name] = expr
+
+        # NOTE: This has the potential to override a positional argument with a keyword.
+        # We also silently take the last keyword argument if a keyword is given more
+        # than once.
+
+        # Update default and/or missing arguments with keyword arguments.
+        excess_kwargs: Dict[str, Expression] = {}
+        for name, expr in self.kwargs:
+            assert isinstance(name, str)
+            if name in macro_names:
+                args[name] = expr
+            else:
+                excess_kwargs[name] = expr
+
+        excess: Dict[str, object] = {
+            "kwargs": {
+                name: expr.evaluate(context) for name, expr in excess_kwargs.items()
+            },
+            "args": [expr.evaluate(context) for expr in excess_args],
+        }
+
+        # NOTE: default arguments are bound late.
+        bound_args: Dict[str, object] = {}
+        for name, expr in args.items():
+            if expr == NIL:
+                bound_args[name] = context.env.undefined(name)
+            else:
+                assert isinstance(expr, Expression)
+                assert isinstance(name, str)
+                bound_args[name] = expr.evaluate(context)
+
+        namespace = ReadOnlyChainMap(bound_args, excess)
+        return context.copy(namespace, disabled_tags=[TAG_INCLUDE])
+
+    def _get_macro(self, context: Context) -> Union[Macro, Undefined]:
+        macro = context.tag_namespace.get("macros", {}).get(
+            self.name, context.env.undefined(self.name)
+        )
+        assert isinstance(macro, (Macro, Undefined))
+        return macro
+
+    def render_to_output(self, context: Context, buffer: TextIO) -> Optional[bool]:
+        macro = self._get_macro(context)
+
+        if is_undefined(macro):
+            buffer.write(str(macro))
+            return False
+
+        assert isinstance(macro, Macro)
+
+        ctx = self._make_context(context, macro)
+        macro.block.render(ctx, buffer)
+
+        return True
+
+    async def render_to_output_async(
+        self, context: Context, buffer: TextIO
+    ) -> Optional[bool]:
+        macro = self._get_macro(context)
+
+        if is_undefined(macro):
+            buffer.write(str(macro))
+            return False
+
+        assert isinstance(macro, Macro)
+
+        ctx = self._make_context(context, macro)
+        await macro.block.render_async(ctx, buffer)
+
+        return True
+
+    def children(self) -> List[ChildNode]:
+        return [
+            *[
+                ChildNode(linenum=self.tok.linenum, expression=expr)
+                for expr in self.args
+            ],
+            *[
+                ChildNode(linenum=self.tok.linenum, expression=arg.expr)
+                for arg in self.kwargs
+            ],
+        ]
+
+
+class MacroTag(Tag):
+    """Macro tag definition."""
+
+    name = TAG_MACRO
+    end = TAG_ENDMACRO
+
+    def __init__(self, env: Environment):
+        super().__init__(env)
+        self.parser = get_parser(self.env)
+
+    def parse(self, stream: TokenStream) -> Node:
+        expect(stream, TOKEN_TAG, value=TAG_MACRO)
+        tok = stream.current
+        stream.next_token()
+
+        expect(stream, TOKEN_EXPRESSION)
+        expr_stream = TokenStream(tokenize_macro_expression(stream.current.value))
+
+        # Name of the macro. Must be a string literal
+        expect(expr_stream, TOKEN_STRING)
+        name = parse_string_literal(expr_stream).value
+        expr_stream.next_token()
+
+        # Args can be positional (no default), or keyword (with default).
+        args = []
+
+        # The argument list might not start with a comma.
+        if expr_stream.current.type == TOKEN_IDENTIFIER:
+            args.append(parse_macro_argument(expr_stream))
+
+        while expr_stream.current.type != TOKEN_EOF:
+            if expr_stream.current.type == TOKEN_COMMA:
+                expr_stream.next_token()  # Eat comma
+                args.append(parse_macro_argument(expr_stream))
+            else:
+                typ = expr_stream.current.type
+                raise LiquidSyntaxError(
+                    f"expected a comma separated list of arguments, found {typ}",
+                    linenum=tok.linenum,
+                )
+
+        stream.next_token()
+        block = self.parser.parse_block(stream, (TAG_ENDMACRO, TOKEN_EOF))
+        expect(stream, TOKEN_TAG, value=TAG_ENDMACRO)
+
+        return MacroNode(tok=tok, name=name, args=args, block=block)
+
+
+class CallTag(Tag):
+    """Call tag definition."""
+
+    name = TAG_CALL
+    block = False
+
+    def parse(self, stream: TokenStream) -> CallNode:
+        expect(stream, TOKEN_TAG, value=TAG_CALL)
+        tok = stream.current
+
+        stream.next_token()
+        expect(stream, TOKEN_EXPRESSION)
+        expr_stream = TokenStream(tokenize_macro_expression(stream.current.value))
+
+        # Name of the macro. Must be a string literal
+        expect(expr_stream, TOKEN_STRING)
+        name = parse_string_literal(expr_stream).value
+        expr_stream.next_token()
+
+        # Args can be positional (no default), or keyword (with default).
+        args = []
+        kwargs = []
+
+        if expr_stream.current.type not in (TOKEN_COMMA, TOKEN_EOF):
+            arg_name, expr = parse_call_argument(expr_stream)
+            if arg_name is None:
+                args.append(expr)
+            else:
+                kwargs.append(CallKeywordArg(arg_name, expr))
+
+        while expr_stream.current.type != TOKEN_EOF:
+            if expr_stream.current.type == TOKEN_COMMA:
+                expr_stream.next_token()  # Eat comma
+
+                arg_name, expr = parse_call_argument(expr_stream)
+                if arg_name is None:
+                    args.append(expr)
+                else:
+                    kwargs.append(CallKeywordArg(arg_name, expr))
+            else:
+                typ = expr_stream.current.type
+                raise LiquidSyntaxError(
+                    f"expected a comma separated list of arguments, found {typ}",
+                    linenum=tok.linenum,
+                )
+
+        return CallNode(tok=tok, name=name, args=args, kwargs=kwargs)
+
+
+def parse_macro_argument(stream: TokenStream) -> MacroArg:
+    """Return the next argument from the given token stream."""
+    name = str(parse_unchained_identifier(stream))
+    stream.next_token()
+
+    if stream.current.type == TOKEN_COLON:
+        # A keyword argument
+        stream.next_token()  # Eat colon
+        default = parse_expression(stream)
+        stream.next_token()
+    else:
+        # A positional argument
+        default = NIL
+
+    return MacroArg(name, default)
+
+
+def parse_call_argument(stream: TokenStream) -> Tuple[Optional[str], Expression]:
+    """Return the next argument from the given token stream."""
+    if stream.peek.type == TOKEN_COLON:
+        # A keyword argument
+        name: Optional[str] = str(parse_unchained_identifier(stream))
+        stream.next_token()
+        stream.next_token()  # Eat colon
+    else:
+        # A positional argument
+        name = None
+
+    expr = parse_expression(stream)
+    stream.next_token()
+
+    return name, expr

--- a/liquid/token.py
+++ b/liquid/token.py
@@ -142,6 +142,9 @@ TOKEN_RBRACKET = sys.intern("rbracket")
 # Assignment
 TOKEN_ASSIGN = sys.intern("assign")
 
+# Non-standard key/value argument separator. Standard liquid uses TOKEN_COLON.
+TOKEN_EQUALS = sys.intern("equals")
+
 operators = {
     "==": TOKEN_EQ,
     "!=": TOKEN_NE,

--- a/tests/filters/test_array.py
+++ b/tests/filters/test_array.py
@@ -33,7 +33,7 @@ from liquid.builtin.filters.array import where
 from liquid.builtin.filters.array import uniq
 from liquid.builtin.filters.array import compact
 
-from liquid.extra.filters.array import index as _index
+from liquid.extra.filters.array import index
 
 
 class Case(NamedTuple):
@@ -753,4 +753,4 @@ class ArrayFilterTestCase(unittest.TestCase):
             ),
         ]
 
-        self._test(_index, test_cases)
+        self._test(index, test_cases)

--- a/tests/filters/test_array.py
+++ b/tests/filters/test_array.py
@@ -1,14 +1,16 @@
-"""Test math filter functions."""
-# pylint: disable=too-many-public-methods,too-many-lines,missing-class-docstring
+"""Test array filter functions."""
+# pylint: disable=too-many-public-methods,too-many-lines
 import unittest
 
 from functools import partial
 from inspect import isclass
 
-from typing import NamedTuple
 from typing import Any
-from typing import List
 from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import NamedTuple
+
 
 from liquid.environment import Environment
 from liquid.expression import NIL
@@ -31,8 +33,12 @@ from liquid.builtin.filters.array import where
 from liquid.builtin.filters.array import uniq
 from liquid.builtin.filters.array import compact
 
+from liquid.extra.filters.array import index as _index
+
 
 class Case(NamedTuple):
+    """Table-driven test helper."""
+
     description: str
     val: Any
     args: List[Any]
@@ -46,7 +52,7 @@ class ArrayFilterTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.env = Environment()
 
-    def _test(self, func, test_cases):
+    def _test(self, func, test_cases: Iterable[Case]):
         if getattr(func, "with_environment", False):
             func = partial(func, environment=self.env)
 
@@ -727,3 +733,24 @@ class ArrayFilterTestCase(unittest.TestCase):
         ]
 
         self._test(compact, test_cases)
+
+    def test_index(self):
+        """Test `index` filter function."""
+        test_cases = [
+            Case(
+                description="array of strings",
+                val=["a", "b", "c"],
+                args=["b"],
+                kwargs={},
+                expect=1,
+            ),
+            Case(
+                description="item does not exist",
+                val=["a", "b", "c"],
+                args=["z"],
+                kwargs={},
+                expect=None,
+            ),
+        ]
+
+        self._test(_index, test_cases)

--- a/tests/filters/test_html.py
+++ b/tests/filters/test_html.py
@@ -1,0 +1,214 @@
+"""Test html filter functions."""
+import unittest
+
+from functools import partial
+from inspect import isclass
+
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import NamedTuple
+
+try:
+    import markupsafe  # pylint: disable=unused-import # noqa: F401
+
+    MARKUPSAFE_AVAILABLE = True
+except ImportError:
+    MARKUPSAFE_AVAILABLE = False
+
+from liquid.environment import Environment
+from liquid.exceptions import Error
+
+from liquid.extra.filters.html import script_tag
+from liquid.extra.filters.html import stylesheet_tag
+
+from liquid import Markup
+
+
+class Case(NamedTuple):
+    """Table-driven test helper."""
+
+    description: str
+    val: Any
+    args: List[Any]
+    kwargs: Dict[Any, Any]
+    expect: Any
+
+
+class HTMLFilterTestCase(unittest.TestCase):
+    """Test HTML filter functions."""
+
+    def setUp(self) -> None:
+        self.env = Environment()
+
+    def _test(self, func, test_cases: Iterable[Case]):
+        if getattr(func, "with_environment", False):
+            func = partial(func, environment=self.env)
+
+        for case in test_cases:
+            with self.subTest(msg=case.description):
+                if isclass(case.expect) and issubclass(case.expect, Error):
+                    with self.assertRaises(case.expect):
+                        func(case.val, *case.args, **case.kwargs)
+                else:
+                    self.assertEqual(
+                        func(case.val, *case.args, **case.kwargs), case.expect
+                    )
+
+    def test_stylesheet_tag(self):
+        """Test `stylesheet_tag` filter function."""
+        test_cases = [
+            Case(
+                description="relative url",
+                val="assets/style.css",
+                args=[],
+                kwargs={},
+                expect=(
+                    '<link href="assets/style.css" rel="stylesheet" '
+                    'type="text/css" media="all" />'
+                ),
+            ),
+            Case(
+                description="remote url",
+                val="https://example.com/static/style.css",
+                args=[],
+                kwargs={},
+                expect=(
+                    '<link href="https://example.com/static/style.css" '
+                    'rel="stylesheet" type="text/css" media="all" />'
+                ),
+            ),
+            Case(
+                description="html escape url",
+                val="<b>assets/style.css</b>",
+                args=[],
+                kwargs={},
+                expect=(
+                    '<link href="&lt;b&gt;assets/style.css&lt;/b&gt;" rel="stylesheet" '
+                    'type="text/css" media="all" />'
+                ),
+            ),
+            Case(
+                description="not a string",
+                val=42,
+                args=[],
+                kwargs={},
+                expect=(
+                    '<link href="42" rel="stylesheet" type="text/css" media="all" />'
+                ),
+            ),
+        ]
+
+        self._test(stylesheet_tag, test_cases)
+
+    @unittest.skipIf(not MARKUPSAFE_AVAILABLE, "this test requires markupsafe")
+    def test_stylesheet_tag_auto_escape(self):
+        """Test `stylesheet_tag` filter function when autoescape is enabled."""
+        test_cases = [
+            Case(
+                description="relative url",
+                val="assets/style.css",
+                args=[],
+                kwargs={},
+                expect=(
+                    '<link href="assets/style.css" rel="stylesheet" '
+                    'type="text/css" media="all" />'
+                ),
+            ),
+            Case(
+                description="unsafe url from context",
+                val="<b>assets/style.css</b>",
+                args=[],
+                kwargs={},
+                expect=(
+                    '<link href="&lt;b&gt;assets/style.css&lt;/b&gt;" rel="stylesheet" '
+                    'type="text/css" media="all" />'
+                ),
+            ),
+            Case(
+                description="safe url from context",
+                val=Markup("<b>assets/style.css</b>"),
+                args=[],
+                kwargs={},
+                expect=(
+                    '<link href="&lt;b&gt;assets/style.css&lt;/b&gt;" rel="stylesheet" '
+                    'type="text/css" media="all" />'
+                ),
+            ),
+        ]
+
+        self.env.autoescape = True
+        self._test(stylesheet_tag, test_cases)
+
+    def test_script_tag(self):
+        """Test `script_tag` filter function."""
+        test_cases = [
+            Case(
+                description="relative url",
+                val="assets/app.js",
+                args=[],
+                kwargs={},
+                expect='<script src="assets/app.js" type="text/javascript"></script>',
+            ),
+            Case(
+                description="remote url",
+                val="https://example.com/static/assets/app.js",
+                args=[],
+                kwargs={},
+                expect=(
+                    "<script "
+                    'src="https://example.com/static/assets/app.js" '
+                    'type="text/javascript">'
+                    "</script>"
+                ),
+            ),
+            Case(
+                description="not a string",
+                val=42,
+                args=[],
+                kwargs={},
+                expect='<script src="42" type="text/javascript"></script>',
+            ),
+        ]
+
+        self._test(script_tag, test_cases)
+
+    @unittest.skipIf(not MARKUPSAFE_AVAILABLE, "this test requires markupsafe")
+    def test_script_tag_auto_escape(self):
+        """Test `script_tag` filter function when autoescape is enabled."""
+        test_cases = [
+            Case(
+                description="relative url",
+                val="assets/assets/app.js",
+                args=[],
+                kwargs={},
+                expect=(
+                    '<script src="assets/assets/app.js" '
+                    'type="text/javascript"></script>'
+                ),
+            ),
+            Case(
+                description="unsafe url from context",
+                val="<b>assets/assets/app.js</b>",
+                args=[],
+                kwargs={},
+                expect=(
+                    '<script src="&lt;b&gt;assets/assets/app.js&lt;/b&gt;" '
+                    'type="text/javascript"></script>'
+                ),
+            ),
+            Case(
+                description="safe url from context",
+                val=Markup("<b>assets/assets/app.js</b>"),
+                args=[],
+                kwargs={},
+                expect=(
+                    '<script src="&lt;b&gt;assets/assets/app.js&lt;/b&gt;" '
+                    'type="text/javascript"></script>'
+                ),
+            ),
+        ]
+
+        self.env.autoescape = True
+        self._test(script_tag, test_cases)

--- a/tests/filters/test_json.py
+++ b/tests/filters/test_json.py
@@ -1,0 +1,122 @@
+"""Test cases for the `json` filter function."""
+import unittest
+
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import is_dataclass
+from inspect import isclass
+
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import NamedTuple
+
+from liquid.environment import Environment
+from liquid.exceptions import Error
+from liquid.exceptions import FilterArgumentError
+from liquid.extra.filters._json import JSON
+
+
+class Case(NamedTuple):
+    """Table-driven test helper."""
+
+    description: str
+    val: Any
+    args: List[Any]
+    kwargs: Dict[Any, Any]
+    expect: Any
+
+
+@dataclass
+class MockData:
+    """Mock data class."""
+
+    length: int
+    width: int
+
+
+class JSONFilterTestCase(unittest.TestCase):
+    """Test the JSON template filter."""
+
+    def setUp(self) -> None:
+        self.env = Environment()
+
+    def _test(self, func, test_cases: Iterable[Case]):
+        for case in test_cases:
+            with self.subTest(msg=case.description):
+                if isclass(case.expect) and issubclass(case.expect, Error):
+                    with self.assertRaises(case.expect):
+                        func(case.val, *case.args, **case.kwargs)
+                else:
+                    self.assertEqual(
+                        func(case.val, *case.args, **case.kwargs), case.expect
+                    )
+
+    def test_json_filter(self) -> None:
+        """Test `json` filter function."""
+        test_cases = [
+            Case(
+                description="serialize a string",
+                val="hello",
+                args=[],
+                kwargs={},
+                expect='"hello"',
+            ),
+            Case(
+                description="serialize an int",
+                val=42,
+                args=[],
+                kwargs={},
+                expect="42",
+            ),
+            Case(
+                description="serialize a dict with list",
+                val={"foo": [1, 2, 3]},
+                args=[],
+                kwargs={},
+                expect='{"foo": [1, 2, 3]}',
+            ),
+            Case(
+                description="serialize an arbitrary object",
+                val={"foo": MockData(3, 4)},
+                args=[],
+                kwargs={},
+                expect=FilterArgumentError,
+            ),
+            Case(
+                description="with indent",
+                val={"foo": [1, 2, 3]},
+                args=[4],
+                kwargs={},
+                expect='{\n    "foo": [\n        1,\n        2,\n        3\n    ]\n}',
+            ),
+        ]
+
+        self._test(JSON(), test_cases)
+
+    def test_json_with_encoder_func(self) -> None:
+        """Test `json` filter function with default encoder."""
+        test_cases = [
+            Case(
+                description="serialize a dataclass",
+                val={"foo": MockData(3, 4)},
+                args=[],
+                kwargs={},
+                expect=r'{"foo": {"length": 3, "width": 4}}',
+            ),
+            Case(
+                description="serialize an arbitrary object",
+                val={"foo": object()},
+                args=[],
+                kwargs={},
+                expect=FilterArgumentError,
+            ),
+        ]
+
+        def default(obj: object) -> Dict[str, Any]:
+            if is_dataclass(obj):
+                return asdict(obj)
+            raise TypeError(f"can't serialize object {obj}")
+
+        self._test(JSON(default=default), test_cases)

--- a/tests/filters/test_misc.py
+++ b/tests/filters/test_misc.py
@@ -33,7 +33,7 @@ class Case(NamedTuple):
     expect: Any
 
 
-class MockDrop:
+class MockDrop:  # pragma: no cover
     def __init__(self, val):
         self.val = val
 
@@ -49,7 +49,7 @@ class MockDrop:
         return self.val
 
 
-class NoLiquidDrop:
+class NoLiquidDrop:  # pragma: no cover
     def __init__(self, val):
         self.val = val
 
@@ -62,7 +62,7 @@ class NoLiquidDrop:
         return "hello no liquid drop"
 
 
-class FalsyDrop:
+class FalsyDrop:  # pragma: no cover
     def __init__(self, val):
         self.val = val
 

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -1,0 +1,343 @@
+"""Test cases for `macro` and `call` tags."""
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+import asyncio
+from unittest import TestCase
+
+from typing import Mapping
+from typing import NamedTuple
+from typing import Any
+from typing import Dict
+
+from liquid.context import StrictUndefined
+from liquid.environment import Environment
+from liquid.exceptions import UndefinedError
+from liquid.loaders import DictLoader
+
+from liquid.token import Token
+from liquid.token import TOKEN_IDENTIFIER
+from liquid.token import TOKEN_STRING
+from liquid.token import TOKEN_INTEGER
+from liquid.token import TOKEN_COLON
+from liquid.token import TOKEN_COMMA
+
+from liquid.extra.tags import MacroTag
+from liquid.extra.tags import CallTag
+from liquid.extra.tags.macro import tokenize_macro_expression
+
+
+class LexerCase(NamedTuple):
+    description: str
+    source: str
+    expect: Any
+
+
+class RenderCase(NamedTuple):
+    description: str
+    template: str
+    expect: str
+    globals: Mapping[str, Any]
+    partials: Dict[str, str]
+
+
+class MacroLexerTestCase(TestCase):
+    def test_lex_macro_expression(self) -> None:
+        """Test that we can tokenize `macro` tags."""
+        test_cases = [
+            LexerCase(
+                description="no args macro",
+                source="'func'",
+                expect=[
+                    Token(1, TOKEN_STRING, "func"),
+                ],
+            ),
+            LexerCase(
+                description="positional args macro",
+                source="'func', foo, bar",
+                expect=[
+                    Token(1, TOKEN_STRING, "func"),
+                    Token(1, TOKEN_COMMA, ","),
+                    Token(1, TOKEN_IDENTIFIER, "foo"),
+                    Token(1, TOKEN_COMMA, ","),
+                    Token(1, TOKEN_IDENTIFIER, "bar"),
+                ],
+            ),
+            LexerCase(
+                description="positional args macro no leading comma",
+                source="'func' foo, bar",
+                expect=[
+                    Token(1, TOKEN_STRING, "func"),
+                    Token(1, TOKEN_IDENTIFIER, "foo"),
+                    Token(1, TOKEN_COMMA, ","),
+                    Token(1, TOKEN_IDENTIFIER, "bar"),
+                ],
+            ),
+            LexerCase(
+                description="keyword args macro",
+                source="'func', foo: 1, bar: 2",
+                expect=[
+                    Token(1, TOKEN_STRING, "func"),
+                    Token(1, TOKEN_COMMA, ","),
+                    Token(1, TOKEN_IDENTIFIER, "foo"),
+                    Token(1, TOKEN_COLON, ":"),
+                    Token(1, TOKEN_INTEGER, "1"),
+                    Token(1, TOKEN_COMMA, ","),
+                    Token(1, TOKEN_IDENTIFIER, "bar"),
+                    Token(1, TOKEN_COLON, ":"),
+                    Token(1, TOKEN_INTEGER, "2"),
+                ],
+            ),
+        ]
+
+        for case in test_cases:
+            with self.subTest(msg=case.description):
+                tokens = list(tokenize_macro_expression(case.source))
+                self.assertTrue(len(tokens), len(case.expect))
+
+                for got, want in zip(tokens, case.expect):
+                    self.assertEqual(got, want)
+
+
+class MacroRenderTestCase(TestCase):
+    def test_render_macro(self) -> None:
+        """Test that we can render `macro` and `call` tags."""
+        test_cases = [
+            RenderCase(
+                description="basic macro no call",
+                template=r"{% macro 'func' %}Hello, World!{% endmacro %}",
+                expect="",
+                globals={},
+                partials={},
+            ),
+            RenderCase(
+                description="call basic macro",
+                template=(
+                    r"{% macro 'func' %}Hello, World!{% endmacro %}"
+                    r"{% call 'func' %}"
+                ),
+                expect="Hello, World!",
+                globals={},
+                partials={},
+            ),
+            RenderCase(
+                description="call basic macro multiple times",
+                template=(
+                    r"{% macro 'func' %}Hello, World!{% endmacro %}"
+                    r"{% call 'func' %}"
+                    r"{% call 'func' %}"
+                ),
+                expect="Hello, World!Hello, World!",
+                globals={},
+                partials={},
+            ),
+            RenderCase(
+                description="call macro with argument",
+                template=(
+                    r"{% macro 'func', you %}Hello, {{ you }}!{% endmacro %}"
+                    r"{% call 'func', 'you' %} "
+                    r"{% call 'func', 'World' %}"
+                ),
+                expect="Hello, you! Hello, World!",
+                globals={},
+                partials={},
+            ),
+            RenderCase(
+                description="call macro with default argument",
+                template=(
+                    r"{% macro 'func' you: 'brian' %}Hello, {{ you }}!{% endmacro %}"
+                    r"{% call 'func' %} "
+                    r"{% call 'func' you: 'World' %}"
+                ),
+                expect="Hello, brian! Hello, World!",
+                globals={},
+                partials={},
+            ),
+            RenderCase(
+                description="boolean literal default argument",
+                template=(
+                    r"{% macro 'func' foo: false %}"
+                    r"{% if foo %}Hello, World!{% endif %}"
+                    r"{% endmacro %}"
+                    r"{% call 'func' %}"
+                    r"{% call 'func' foo: true %}"
+                ),
+                expect="Hello, World!",
+                globals={},
+                partials={},
+            ),
+            RenderCase(
+                description="chained default argument from context",
+                template=(
+                    r"{% macro 'func' greeting: foo.bar %}"
+                    r"{{ greeting }}, World!"
+                    r"{% endmacro %}"
+                    r"{% call 'func' %}"
+                    r"{% call 'func' greeting: 'Goodbye' %}"
+                ),
+                expect="Hello, World!Goodbye, World!",
+                globals={"foo": {"bar": "Hello"}},
+                partials={},
+            ),
+            RenderCase(
+                description="excess arguments",
+                template=(
+                    r"{% macro 'func' %}"
+                    r"{{ args | join: '-' }}"
+                    r"{% endmacro %}"
+                    r"{% call 'func' 1, 2 %}"
+                ),
+                expect="1-2",
+                globals={},
+                partials={},
+            ),
+            RenderCase(
+                description="excess keyword arguments",
+                template=(
+                    r"{% macro 'func' %}"
+                    r"{% for arg in kwargs %}"
+                    r"{{ arg[0] }} => {{ arg[1] }}, "
+                    r"{% endfor %}"
+                    r"{% endmacro %}"
+                    r"{% call 'func', a: 1, b: 2 %}"
+                ),
+                expect="a => 1, b => 2, ",
+                globals={},
+                partials={},
+            ),
+            RenderCase(
+                description="missing argument",
+                template=(
+                    r"{% macro 'func', foo %}"
+                    r"{{ foo }}"
+                    r"{% endmacro %}"
+                    r"{% call 'func' %}"
+                ),
+                expect="",
+                globals={},
+                partials={},
+            ),
+            RenderCase(
+                description="undefined macro",
+                template=(r"{% call 'func' %}"),
+                expect="",
+                globals={},
+                partials={},
+            ),
+            RenderCase(
+                description="default before positional",
+                template=(
+                    r"{% macro 'func' you: 'brian', greeting %}"
+                    r"{{ greeting }}, {{ you }}!"
+                    r"{% endmacro %}"
+                    r"{% call 'func' %} "
+                    r"{% call 'func' you: 'World', greeting: 'Goodbye' %}"
+                ),
+                expect=", brian! Goodbye, World!",
+                globals={},
+                partials={},
+            ),
+        ]
+
+        for case in test_cases:
+            env = Environment(loader=DictLoader(case.partials))
+            env.add_tag(MacroTag)
+            env.add_tag(CallTag)
+
+            template = env.from_string(case.template, globals=case.globals)
+
+            with self.subTest(msg=case.description):
+                result = template.render()
+                self.assertEqual(result, case.expect)
+
+    def test_render_macro_strict_undefined(self) -> None:
+        """Test that missing arguments and undefined macros are `Undefined`."""
+        test_cases = [
+            RenderCase(
+                description="missing argument",
+                template=(
+                    r"{% macro 'func', foo %}"
+                    r"{{ foo }}"
+                    r"{% endmacro %}"
+                    r"{% call 'func' %}"
+                ),
+                expect="'foo' is undefined, on line 1",
+                globals={},
+                partials={},
+            ),
+            RenderCase(
+                description="undefined macro",
+                template=(r"{% call 'func' %}"),
+                expect="'func' is undefined, on line 1",
+                globals={},
+                partials={},
+            ),
+        ]
+
+        for case in test_cases:
+            env = Environment(
+                loader=DictLoader(case.partials),
+                undefined=StrictUndefined,
+            )
+            env.add_tag(MacroTag)
+            env.add_tag(CallTag)
+
+            template = env.from_string(case.template, globals=case.globals)
+
+            with self.subTest(msg=case.description):
+                with self.assertRaises(UndefinedError) as raised:
+                    template.render()
+                self.assertEqual(case.expect, str(raised.exception))
+
+    def test_render_macro_async(self) -> None:
+        """Test that we can render a macro asynchronously."""
+        env = Environment()
+        env.add_tag(MacroTag)
+        env.add_tag(CallTag)
+
+        template = env.from_string(
+            r"{% macro 'foo', you: 'World' %}"
+            r"Hello, {{ you }}!"
+            r"{% endmacro %}"
+            r"{% call 'foo' %}"
+            r"{% call 'foo', you: 'you' %}"
+            r"{% call 'nosuchthing' %}"
+        )
+
+        async def coro() -> str:
+            return await template.render_async()
+
+        result = asyncio.run(coro())
+        self.assertEqual(result, "Hello, World!Hello, you!")
+
+
+class AnalyzeMacroTestCase(TestCase):
+    def test_analyze_macro_tag(self) -> None:
+        """Test that we can statically analyze macro and call tags."""
+        env = Environment()
+        env.add_tag(MacroTag)
+        env.add_tag(CallTag)
+
+        template = env.from_string(
+            r"{% macro 'foo', you: 'World', arg: n %}"
+            r"Hello, {{ you }}!"
+            r"{% endmacro %}"
+            r"{% call 'foo' %}"
+            r"{% assign x = 'you' %}"
+            r"{% call 'foo', you: x %}"
+        )
+
+        expected_template_globals = {
+            "n": [("<string>", 1)],
+        }
+        expected_template_locals = {"x": [("<string>", 1)]}
+        expected_refs = {
+            "n": [("<string>", 1)],
+            "you": [("<string>", 1)],
+            "x": [("<string>", 1)],
+        }
+
+        analysis = template.analyze()
+
+        self.assertEqual(analysis.local_variables, expected_template_locals)
+        self.assertEqual(analysis.global_variables, expected_template_globals)
+        self.assertEqual(analysis.variables, expected_refs)

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -10,10 +10,8 @@ from typing import Dict
 from liquid.context import StrictUndefined
 from liquid.environment import Environment
 from liquid.exceptions import UndefinedError
+from liquid.extra import add_macros
 from liquid.loaders import DictLoader
-
-from liquid.extra.tags import MacroTag
-from liquid.extra.tags import CallTag
 
 
 class Case(NamedTuple):
@@ -170,8 +168,7 @@ class MacroRenderTestCase(TestCase):
 
         for case in test_cases:
             env = Environment(loader=DictLoader(case.partials))
-            env.add_tag(MacroTag)
-            env.add_tag(CallTag)
+            add_macros(env)
 
             template = env.from_string(case.template, globals=case.globals)
 
@@ -208,8 +205,7 @@ class MacroRenderTestCase(TestCase):
                 loader=DictLoader(case.partials),
                 undefined=StrictUndefined,
             )
-            env.add_tag(MacroTag)
-            env.add_tag(CallTag)
+            add_macros(env)
 
             template = env.from_string(case.template, globals=case.globals)
 
@@ -221,8 +217,7 @@ class MacroRenderTestCase(TestCase):
     def test_render_macro_async(self) -> None:
         """Test that we can render a macro asynchronously."""
         env = Environment()
-        env.add_tag(MacroTag)
-        env.add_tag(CallTag)
+        add_macros(env)
 
         template = env.from_string(
             r"{% macro 'foo', you: 'World' %}"
@@ -246,8 +241,7 @@ class AnalyzeMacroTestCase(TestCase):
     def test_analyze_macro_tag(self) -> None:
         """Test that we can statically analyze macro and call tags."""
         env = Environment()
-        env.add_tag(MacroTag)
-        env.add_tag(CallTag)
+        add_macros(env)
 
         template = env.from_string(
             r"{% macro 'foo', you: 'World', arg: n %}"

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -1,6 +1,4 @@
 """Test cases for `macro` and `call` tags."""
-# pylint: disable=missing-class-docstring,missing-function-docstring
-
 import asyncio
 from unittest import TestCase
 
@@ -14,25 +12,13 @@ from liquid.environment import Environment
 from liquid.exceptions import UndefinedError
 from liquid.loaders import DictLoader
 
-from liquid.token import Token
-from liquid.token import TOKEN_IDENTIFIER
-from liquid.token import TOKEN_STRING
-from liquid.token import TOKEN_INTEGER
-from liquid.token import TOKEN_COLON
-from liquid.token import TOKEN_COMMA
-
 from liquid.extra.tags import MacroTag
 from liquid.extra.tags import CallTag
-from liquid.extra.tags.macro import tokenize_macro_expression
 
 
-class LexerCase(NamedTuple):
-    description: str
-    source: str
-    expect: Any
+class Case(NamedTuple):
+    """Table-driven test helper."""
 
-
-class RenderCase(NamedTuple):
     description: str
     template: str
     expect: str
@@ -40,76 +26,20 @@ class RenderCase(NamedTuple):
     partials: Dict[str, str]
 
 
-class MacroLexerTestCase(TestCase):
-    def test_lex_macro_expression(self) -> None:
-        """Test that we can tokenize `macro` tags."""
-        test_cases = [
-            LexerCase(
-                description="no args macro",
-                source="'func'",
-                expect=[
-                    Token(1, TOKEN_STRING, "func"),
-                ],
-            ),
-            LexerCase(
-                description="positional args macro",
-                source="'func', foo, bar",
-                expect=[
-                    Token(1, TOKEN_STRING, "func"),
-                    Token(1, TOKEN_COMMA, ","),
-                    Token(1, TOKEN_IDENTIFIER, "foo"),
-                    Token(1, TOKEN_COMMA, ","),
-                    Token(1, TOKEN_IDENTIFIER, "bar"),
-                ],
-            ),
-            LexerCase(
-                description="positional args macro no leading comma",
-                source="'func' foo, bar",
-                expect=[
-                    Token(1, TOKEN_STRING, "func"),
-                    Token(1, TOKEN_IDENTIFIER, "foo"),
-                    Token(1, TOKEN_COMMA, ","),
-                    Token(1, TOKEN_IDENTIFIER, "bar"),
-                ],
-            ),
-            LexerCase(
-                description="keyword args macro",
-                source="'func', foo: 1, bar: 2",
-                expect=[
-                    Token(1, TOKEN_STRING, "func"),
-                    Token(1, TOKEN_COMMA, ","),
-                    Token(1, TOKEN_IDENTIFIER, "foo"),
-                    Token(1, TOKEN_COLON, ":"),
-                    Token(1, TOKEN_INTEGER, "1"),
-                    Token(1, TOKEN_COMMA, ","),
-                    Token(1, TOKEN_IDENTIFIER, "bar"),
-                    Token(1, TOKEN_COLON, ":"),
-                    Token(1, TOKEN_INTEGER, "2"),
-                ],
-            ),
-        ]
-
-        for case in test_cases:
-            with self.subTest(msg=case.description):
-                tokens = list(tokenize_macro_expression(case.source))
-                self.assertTrue(len(tokens), len(case.expect))
-
-                for got, want in zip(tokens, case.expect):
-                    self.assertEqual(got, want)
-
-
 class MacroRenderTestCase(TestCase):
+    """Test cases for rendering the `macro` and `call` tags."""
+
     def test_render_macro(self) -> None:
         """Test that we can render `macro` and `call` tags."""
         test_cases = [
-            RenderCase(
+            Case(
                 description="basic macro no call",
                 template=r"{% macro 'func' %}Hello, World!{% endmacro %}",
                 expect="",
                 globals={},
                 partials={},
             ),
-            RenderCase(
+            Case(
                 description="call basic macro",
                 template=(
                     r"{% macro 'func' %}Hello, World!{% endmacro %}"
@@ -119,7 +49,7 @@ class MacroRenderTestCase(TestCase):
                 globals={},
                 partials={},
             ),
-            RenderCase(
+            Case(
                 description="call basic macro multiple times",
                 template=(
                     r"{% macro 'func' %}Hello, World!{% endmacro %}"
@@ -130,7 +60,7 @@ class MacroRenderTestCase(TestCase):
                 globals={},
                 partials={},
             ),
-            RenderCase(
+            Case(
                 description="call macro with argument",
                 template=(
                     r"{% macro 'func', you %}Hello, {{ you }}!{% endmacro %}"
@@ -141,7 +71,7 @@ class MacroRenderTestCase(TestCase):
                 globals={},
                 partials={},
             ),
-            RenderCase(
+            Case(
                 description="call macro with default argument",
                 template=(
                     r"{% macro 'func' you: 'brian' %}Hello, {{ you }}!{% endmacro %}"
@@ -152,7 +82,7 @@ class MacroRenderTestCase(TestCase):
                 globals={},
                 partials={},
             ),
-            RenderCase(
+            Case(
                 description="boolean literal default argument",
                 template=(
                     r"{% macro 'func' foo: false %}"
@@ -165,7 +95,7 @@ class MacroRenderTestCase(TestCase):
                 globals={},
                 partials={},
             ),
-            RenderCase(
+            Case(
                 description="chained default argument from context",
                 template=(
                     r"{% macro 'func' greeting: foo.bar %}"
@@ -178,7 +108,7 @@ class MacroRenderTestCase(TestCase):
                 globals={"foo": {"bar": "Hello"}},
                 partials={},
             ),
-            RenderCase(
+            Case(
                 description="excess arguments",
                 template=(
                     r"{% macro 'func' %}"
@@ -190,7 +120,7 @@ class MacroRenderTestCase(TestCase):
                 globals={},
                 partials={},
             ),
-            RenderCase(
+            Case(
                 description="excess keyword arguments",
                 template=(
                     r"{% macro 'func' %}"
@@ -204,7 +134,7 @@ class MacroRenderTestCase(TestCase):
                 globals={},
                 partials={},
             ),
-            RenderCase(
+            Case(
                 description="missing argument",
                 template=(
                     r"{% macro 'func', foo %}"
@@ -216,14 +146,14 @@ class MacroRenderTestCase(TestCase):
                 globals={},
                 partials={},
             ),
-            RenderCase(
+            Case(
                 description="undefined macro",
                 template=(r"{% call 'func' %}"),
                 expect="",
                 globals={},
                 partials={},
             ),
-            RenderCase(
+            Case(
                 description="default before positional",
                 template=(
                     r"{% macro 'func' you: 'brian', greeting %}"
@@ -252,7 +182,7 @@ class MacroRenderTestCase(TestCase):
     def test_render_macro_strict_undefined(self) -> None:
         """Test that missing arguments and undefined macros are `Undefined`."""
         test_cases = [
-            RenderCase(
+            Case(
                 description="missing argument",
                 template=(
                     r"{% macro 'func', foo %}"
@@ -264,7 +194,7 @@ class MacroRenderTestCase(TestCase):
                 globals={},
                 partials={},
             ),
-            RenderCase(
+            Case(
                 description="undefined macro",
                 template=(r"{% call 'func' %}"),
                 expect="'func' is undefined, on line 1",
@@ -311,6 +241,8 @@ class MacroRenderTestCase(TestCase):
 
 
 class AnalyzeMacroTestCase(TestCase):
+    """Test cases for analyzing `macro` and `call` tags."""
+
     def test_analyze_macro_tag(self) -> None:
         """Test that we can statically analyze macro and call tags."""
         env = Environment()

--- a/tests/test_malformed.py
+++ b/tests/test_malformed.py
@@ -24,8 +24,8 @@ from liquid.exceptions import TemplateNotFound
 from liquid.exceptions import DisabledTagError
 from liquid.exceptions import ContextDepthError
 
-from liquid.extra import register_inline_if_expressions
-from liquid.extra import register_inline_if_expressions_with_parens
+from liquid.extra import add_inline_expressions
+from liquid.extra import add_extended_inline_expressions
 from liquid.extra import IfNotTag
 
 from liquid.loaders import DictLoader
@@ -68,7 +68,7 @@ class MalformedTemplateTestCase(TestCase):
         # Test with non-standard conditional and boolean expressions
         env = Environment(tolerance=mode)
         env.add_tag(IfNotTag)
-        register_inline_if_expressions(env)
+        add_inline_expressions(env)
         # Skip test cases that are not considered malformed with non-standard
         # expressions.
         self._test_with_env(
@@ -76,7 +76,7 @@ class MalformedTemplateTestCase(TestCase):
         )
 
         # Same again for conditional expressions that support `not` and parens.
-        register_inline_if_expressions_with_parens(env)
+        add_extended_inline_expressions(env)
         self._test_with_env(
             env, [case for case in test_cases if "||" not in case.template]
         )

--- a/tests/test_parse_arguments.py
+++ b/tests/test_parse_arguments.py
@@ -1,3 +1,4 @@
+"""Test cases for parsing list of positional and keyword arguments."""
 import unittest
 
 from typing import List
@@ -7,14 +8,22 @@ from typing import Tuple
 from typing import Union
 
 from liquid.expression import Expression
+from liquid.expression import FloatLiteral
 from liquid.expression import IdentifierPathElement
 from liquid.expression import Identifier
 from liquid.expression import IntegerLiteral
-from liquid.expression import RangeLiteral
+from liquid.expression import StringLiteral
+from liquid.expression import FALSE
+from liquid.expression import TRUE
+from liquid.expression import NIL
 
 from liquid.expressions import parse_call_arguments
 from liquid.expressions import parse_keyword_arguments
 from liquid.expressions import parse_macro_arguments
+
+from liquid.expressions.arguments.lex import tokenize
+from liquid.expressions.arguments.parse import parse_equals_separated_arguments
+from liquid.expressions.stream import TokenStream
 
 from liquid.exceptions import Error
 from liquid.exceptions import LiquidSyntaxError
@@ -30,4 +39,415 @@ class Case(NamedTuple):
     expect: Union[Arguments, Error]
 
 
-# TODO: tests
+class ParseKeywordArgumentsTestCase(unittest.TestCase):
+    """Test cases for parsing keyword arguments."""
+
+    def test_parse_keywords(self) -> None:
+        """Test that we can parse a list of keyword arguments."""
+        test_cases = [
+            Case(
+                description="empty expression",
+                expression="",
+                expect=[],
+            ),
+            Case(
+                description="string literal value",
+                expression="val: 'hello'",
+                expect=[("val", StringLiteral("hello"))],
+            ),
+            Case(
+                description="no whitespace",
+                expression="val:'hello'",
+                expect=[("val", StringLiteral("hello"))],
+            ),
+            Case(
+                description="extra whitespace",
+                expression="val :    'hello'",
+                expect=[("val", StringLiteral("hello"))],
+            ),
+            Case(
+                description="newline",
+                expression="val:\n'hello'",
+                expect=[("val", StringLiteral("hello"))],
+            ),
+            Case(
+                description="leading comma",
+                expression=", val: 'hello'",
+                expect=[("val", StringLiteral("hello"))],
+            ),
+            Case(
+                description="trailing comma",
+                expression="val: 'hello',",
+                expect=[("val", StringLiteral("hello"))],
+            ),
+            Case(
+                description="multiple arguments",
+                expression="a: 'hello', b: 'goodbye', c: 'you'",
+                expect=[
+                    ("a", StringLiteral("hello")),
+                    ("b", StringLiteral("goodbye")),
+                    ("c", StringLiteral("you")),
+                ],
+            ),
+            Case(
+                description="literal types",
+                expression="a: 'hello', b: false, c: true, d: nil, e: 1, f: 1.1",
+                expect=[
+                    ("a", StringLiteral("hello")),
+                    ("b", FALSE),
+                    ("c", TRUE),
+                    ("d", NIL),
+                    ("e", IntegerLiteral(1)),
+                    ("f", FloatLiteral(1.1)),
+                ],
+            ),
+            Case(
+                description="identifiers",
+                expression=(
+                    "a: title, b: product.title, "
+                    "c: products[0], d: products['foo'].title"
+                ),
+                expect=[
+                    ("a", Identifier([IdentifierPathElement("title")])),
+                    (
+                        "b",
+                        Identifier(
+                            [
+                                IdentifierPathElement("product"),
+                                IdentifierPathElement("title"),
+                            ]
+                        ),
+                    ),
+                    (
+                        "c",
+                        Identifier(
+                            [
+                                IdentifierPathElement("products"),
+                                IdentifierPathElement(0),
+                            ]
+                        ),
+                    ),
+                    (
+                        "d",
+                        Identifier(
+                            [
+                                IdentifierPathElement("products"),
+                                IdentifierPathElement("foo"),
+                                IdentifierPathElement("title"),
+                            ]
+                        ),
+                    ),
+                ],
+            ),
+        ]
+
+        for case in test_cases:
+            with self.subTest(msg=case.description):
+                args = parse_keyword_arguments(case.expression)
+                self.assertEqual(args, dict(case.expect))
+
+    def test_parse_equals_separated_arguments(self) -> None:
+        """Test that we can use `=` instead of `:` to separate key/value pairs."""
+        expr = "a='hello', b=false, c=true, d=nil, e=1, f=1.1"
+        expect = [
+            ("a", StringLiteral("hello")),
+            ("b", FALSE),
+            ("c", TRUE),
+            ("d", NIL),
+            ("e", IntegerLiteral(1)),
+            ("f", FloatLiteral(1.1)),
+        ]
+        args = dict(parse_equals_separated_arguments(TokenStream(tokenize(expr))))
+        self.assertEqual(args, dict(expect))
+
+    def test_missing_comma(self) -> None:
+        """Test that we handle missing commas."""
+        expr = "a: 'hello' b: 'goodbye'"
+        with self.assertRaises(LiquidSyntaxError):
+            parse_keyword_arguments(expr)
+
+    def test_too_many_commas(self) -> None:
+        """Test that we handle excess commas."""
+        expr = "a: 'hello',, b: 'goodbye'"
+        with self.assertRaises(LiquidSyntaxError):
+            parse_keyword_arguments(expr)
+
+    def test_missing_colon(self) -> None:
+        """Test that we handle missing colons."""
+        expr = "a 'hello'"
+        with self.assertRaises(LiquidSyntaxError):
+            parse_keyword_arguments(expr)
+
+    def test_too_many_colon(self) -> None:
+        """Test that we handle excess colons."""
+        expr = "a:: 'hello'"
+        with self.assertRaises(LiquidSyntaxError):
+            parse_keyword_arguments(expr)
+
+
+class ParseCallArgumentsTestCase(unittest.TestCase):
+    """Test cases for parsing call-style argument lists."""
+
+    def test_parse_call_arguments(self) -> None:
+        """Test that we can parse a list of positional and/or keyword arguments."""
+        test_cases = [
+            Case(
+                description="empty expression",
+                expression="",
+                expect=[],
+            ),
+            Case(
+                description="string literal value",
+                expression="val: 'hello'",
+                expect=[("val", StringLiteral("hello"))],
+            ),
+            Case(
+                description="no whitespace",
+                expression="val:'hello'",
+                expect=[("val", StringLiteral("hello"))],
+            ),
+            Case(
+                description="extra whitespace",
+                expression="val :    'hello'",
+                expect=[("val", StringLiteral("hello"))],
+            ),
+            Case(
+                description="multiple arguments",
+                expression="a: 'hello', b: 'goodbye', c: 'you'",
+                expect=[
+                    ("a", StringLiteral("hello")),
+                    ("b", StringLiteral("goodbye")),
+                    ("c", StringLiteral("you")),
+                ],
+            ),
+            Case(
+                description="literal types",
+                expression="a: 'hello', b: false, c: true, d: nil, e: 1, f: 1.1",
+                expect=[
+                    ("a", StringLiteral("hello")),
+                    ("b", FALSE),
+                    ("c", TRUE),
+                    ("d", NIL),
+                    ("e", IntegerLiteral(1)),
+                    ("f", FloatLiteral(1.1)),
+                ],
+            ),
+            Case(
+                description="identifiers",
+                expression=(
+                    "a: title, b: product.title, c: products[0], d: products[0].title"
+                ),
+                expect=[
+                    ("a", Identifier([IdentifierPathElement("title")])),
+                    (
+                        "b",
+                        Identifier(
+                            [
+                                IdentifierPathElement("product"),
+                                IdentifierPathElement("title"),
+                            ]
+                        ),
+                    ),
+                    (
+                        "c",
+                        Identifier(
+                            [
+                                IdentifierPathElement("products"),
+                                IdentifierPathElement(0),
+                            ]
+                        ),
+                    ),
+                    (
+                        "d",
+                        Identifier(
+                            [
+                                IdentifierPathElement("products"),
+                                IdentifierPathElement(0),
+                                IdentifierPathElement("title"),
+                            ]
+                        ),
+                    ),
+                ],
+            ),
+            Case(
+                description="positional argument",
+                expression="'hello'",
+                expect=[(None, StringLiteral("hello"))],
+            ),
+            Case(
+                description="multiple positional arguments",
+                expression="'hello', 'you'",
+                expect=[(None, StringLiteral("hello")), (None, StringLiteral("you"))],
+            ),
+            Case(
+                description="positional no whitespace",
+                expression="'hello','you'",
+                expect=[(None, StringLiteral("hello")), (None, StringLiteral("you"))],
+            ),
+            Case(
+                description="positional extra whitespace",
+                expression="'hello'  ,    'you'",
+                expect=[(None, StringLiteral("hello")), (None, StringLiteral("you"))],
+            ),
+            Case(
+                description="positional argument followed by keyword",
+                expression="'hello', greeting: 'you'",
+                expect=[
+                    (None, StringLiteral("hello")),
+                    ("greeting", StringLiteral("you")),
+                ],
+            ),
+            Case(
+                description="keyword argument followed by positional",
+                expression="greeting: 'you', 'hello'",
+                expect=[
+                    ("greeting", StringLiteral("you")),
+                    (None, StringLiteral("hello")),
+                ],
+            ),
+        ]
+
+        for case in test_cases:
+            with self.subTest(msg=case.description):
+                args = parse_call_arguments(case.expression)
+                self.assertEqual(args, case.expect)
+
+    def test_missing_comma(self) -> None:
+        """Test that we handle missing commas."""
+        expr = "a: 'hello' b: 'goodbye'"
+        with self.assertRaises(LiquidSyntaxError):
+            parse_call_arguments(expr)
+
+    def test_too_many_commas(self) -> None:
+        """Test that we handle excess commas."""
+        expr = "a: 'hello',, b: 'goodbye'"
+        with self.assertRaises(LiquidSyntaxError):
+            parse_call_arguments(expr)
+
+
+class ParseMacroArgumentsTestCase(unittest.TestCase):
+    """Test cases for parsing macro-style argument lists."""
+
+    def test_parse_call_arguments(self) -> None:
+        """Test that we can parse a list of positional and/or keyword arguments."""
+        test_cases = [
+            Case(
+                description="empty expression",
+                expression="",
+                expect=[],
+            ),
+            Case(
+                description="string literal value",
+                expression="val: 'hello'",
+                expect=[("val", StringLiteral("hello"))],
+            ),
+            Case(
+                description="no whitespace",
+                expression="val:'hello'",
+                expect=[("val", StringLiteral("hello"))],
+            ),
+            Case(
+                description="extra whitespace",
+                expression="val :    'hello'",
+                expect=[("val", StringLiteral("hello"))],
+            ),
+            Case(
+                description="multiple arguments",
+                expression="a: 'hello', b: 'goodbye', c: 'you'",
+                expect=[
+                    ("a", StringLiteral("hello")),
+                    ("b", StringLiteral("goodbye")),
+                    ("c", StringLiteral("you")),
+                ],
+            ),
+            Case(
+                description="literal types",
+                expression="a: 'hello', b: false, c: true, d: nil, e: 1, f: 1.1",
+                expect=[
+                    ("a", StringLiteral("hello")),
+                    ("b", FALSE),
+                    ("c", TRUE),
+                    ("d", NIL),
+                    ("e", IntegerLiteral(1)),
+                    ("f", FloatLiteral(1.1)),
+                ],
+            ),
+            Case(
+                description="identifiers",
+                expression=(
+                    "a: title, b: product.title, c: products[0], d: products[0].title"
+                ),
+                expect=[
+                    ("a", Identifier([IdentifierPathElement("title")])),
+                    (
+                        "b",
+                        Identifier(
+                            [
+                                IdentifierPathElement("product"),
+                                IdentifierPathElement("title"),
+                            ]
+                        ),
+                    ),
+                    (
+                        "c",
+                        Identifier(
+                            [
+                                IdentifierPathElement("products"),
+                                IdentifierPathElement(0),
+                            ]
+                        ),
+                    ),
+                    (
+                        "d",
+                        Identifier(
+                            [
+                                IdentifierPathElement("products"),
+                                IdentifierPathElement(0),
+                                IdentifierPathElement("title"),
+                            ]
+                        ),
+                    ),
+                ],
+            ),
+            Case(
+                description="identifier without a default value",
+                expression="name",
+                expect=[("name", NIL)],
+            ),
+            Case(
+                description="multiple identifiers without a default value",
+                expression="name, greeting",
+                expect=[("name", NIL), ("greeting", NIL)],
+            ),
+            Case(
+                description=(
+                    "identifier without default followed by identifier with a default"
+                ),
+                expression="name, greeting: 'hello'",
+                expect=[("name", NIL), ("greeting", StringLiteral("hello"))],
+            ),
+            Case(
+                description=(
+                    "identifier with a default followed by identifier without default"
+                ),
+                expression="greeting: 'hello', name",
+                expect=[("greeting", StringLiteral("hello")), ("name", NIL)],
+            ),
+        ]
+
+        for case in test_cases:
+            with self.subTest(msg=case.description):
+                args = parse_macro_arguments(case.expression)
+                self.assertEqual(args, case.expect)
+
+    def test_missing_comma(self) -> None:
+        """Test that we handle missing commas."""
+        expr = "a: 'hello' b: 'goodbye'"
+        with self.assertRaises(LiquidSyntaxError):
+            parse_macro_arguments(expr)
+
+    def test_too_many_commas(self) -> None:
+        """Test that we handle excess commas."""
+        expr = "a: 'hello',, b: 'goodbye'"
+        with self.assertRaises(LiquidSyntaxError):
+            parse_macro_arguments(expr)

--- a/tests/test_parse_arguments.py
+++ b/tests/test_parse_arguments.py
@@ -309,18 +309,19 @@ class ParseCallArgumentsTestCase(unittest.TestCase):
 
         for case in test_cases:
             with self.subTest(msg=case.description):
-                args = parse_call_arguments(case.expression)
+                expr = "'func' " + case.expression  # pretend macro name
+                _, args = parse_call_arguments(expr)
                 self.assertEqual(args, case.expect)
 
     def test_missing_comma(self) -> None:
         """Test that we handle missing commas."""
-        expr = "a: 'hello' b: 'goodbye'"
+        expr = "'func' a: 'hello' b: 'goodbye'"
         with self.assertRaises(LiquidSyntaxError):
             parse_call_arguments(expr)
 
     def test_too_many_commas(self) -> None:
         """Test that we handle excess commas."""
-        expr = "a: 'hello',, b: 'goodbye'"
+        expr = "'func' a: 'hello',, b: 'goodbye'"
         with self.assertRaises(LiquidSyntaxError):
             parse_call_arguments(expr)
 
@@ -437,17 +438,19 @@ class ParseMacroArgumentsTestCase(unittest.TestCase):
 
         for case in test_cases:
             with self.subTest(msg=case.description):
-                args = parse_macro_arguments(case.expression)
+                expr = "'func' " + case.expression  # pretend macro name
+                name, args = parse_macro_arguments(expr)
+                self.assertEqual(name, "func")
                 self.assertEqual(args, case.expect)
 
     def test_missing_comma(self) -> None:
         """Test that we handle missing commas."""
-        expr = "a: 'hello' b: 'goodbye'"
+        expr = "'func' a: 'hello' b: 'goodbye'"
         with self.assertRaises(LiquidSyntaxError):
             parse_macro_arguments(expr)
 
     def test_too_many_commas(self) -> None:
         """Test that we handle excess commas."""
-        expr = "a: 'hello',, b: 'goodbye'"
+        expr = "'func' a: 'hello',, b: 'goodbye'"
         with self.assertRaises(LiquidSyntaxError):
             parse_macro_arguments(expr)

--- a/tests/test_parse_arguments.py
+++ b/tests/test_parse_arguments.py
@@ -1,0 +1,33 @@
+import unittest
+
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+from liquid.expression import Expression
+from liquid.expression import IdentifierPathElement
+from liquid.expression import Identifier
+from liquid.expression import IntegerLiteral
+from liquid.expression import RangeLiteral
+
+from liquid.expressions import parse_call_arguments
+from liquid.expressions import parse_keyword_arguments
+from liquid.expressions import parse_macro_arguments
+
+from liquid.exceptions import Error
+from liquid.exceptions import LiquidSyntaxError
+
+Arguments = List[Tuple[Optional[str], Optional[Expression]]]
+
+
+class Case(NamedTuple):
+    """Table-driven test helper."""
+
+    description: str
+    expression: str
+    expect: Union[Arguments, Error]
+
+
+# TODO: tests

--- a/tests/test_registered_filters.py
+++ b/tests/test_registered_filters.py
@@ -2,10 +2,10 @@
 
 import datetime
 import unittest
-
 from typing import NamedTuple
 
 from liquid import Environment
+from liquid.extra import add_filters
 
 
 class Case(NamedTuple):
@@ -17,11 +17,11 @@ class Case(NamedTuple):
     expect: str
 
 
-class FilterResgisterTestCase(unittest.TestCase):
+class FilterRegisterTestCase(unittest.TestCase):
     """Test that all standard filters have been registered correctly."""
 
-    def test_filters(self):
-        """Standard filter tests"""
+    def test_filters(self) -> None:
+        """Standard filter tests."""
         test_cases = [
             Case(
                 description="append",
@@ -370,6 +370,51 @@ class FilterResgisterTestCase(unittest.TestCase):
         ]
 
         env = Environment()
+
+        for case in test_cases:
+            with self.subTest(msg=case.description):
+                template = env.from_string(case.template)
+                result = template.render(**case.context)
+                self.assertEqual(result, case.expect)
+
+
+class ExtraFilterRegistrationTestCase(unittest.TestCase):
+    """Test that we can add all extra filters."""
+
+    def test_extra_filters(self) -> None:
+        """Extra filter tests."""
+        test_cases = [
+            Case(
+                description="array index",
+                template="{{ array | index: 'b' }}",
+                context={"array": ["a", "b", "c"]},
+                expect="1",
+            ),
+            Case(
+                description="stylesheet tag",
+                template="{{ url | stylesheet_tag }}",
+                context={"url": "assets/style.css"},
+                expect=(
+                    '<link href="assets/style.css" rel="stylesheet" '
+                    'type="text/css" media="all" />'
+                ),
+            ),
+            Case(
+                description="stylesheet tag",
+                template="{{ url | script_tag }}",
+                context={"url": "assets/app.js"},
+                expect='<script src="assets/app.js" type="text/javascript"></script>',
+            ),
+            Case(
+                description="JSON",
+                template="{{ data | json }}",
+                context={"data": {"foo": [1, 2, 3]}},
+                expect='{"foo": [1, 2, 3]}',
+            ),
+        ]
+
+        env = Environment()
+        add_filters(env)
 
         for case in test_cases:
             with self.subTest(msg=case.description):


### PR DESCRIPTION
Following on from #83, this pull request adds implementations of the `macro` and `call` tags, the `with` tag, and the filters from [Python Liquid Extra](https://github.com/jg-rp/liquid-extra).