### PR TITLE
Variables as tuples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,15 +1,21 @@
 Python Liquid Change Log
 ========================
 
-Version 1.5.2 (unreleased)
+Version 1.6.0 (unreleased)
 --------------------------
 
 **Fixes**
 
 - Fixed the string representation of ``liquid.expression.Identifier``, which is exposed
-  in the results of ``liquid.Template.analyze()``. We now represent variable path
+  in the results of ``liquid.BoundTemplate.analyze()``. We now represent variable path
   elements containing a ``.`` as quoted strings inside square brackets.
   See `#87 <https://github.com/jg-rp/liquid/issues/87>`_.
+
+**Features**
+
+- The dictionaries returned by ``liquid.BoundTemplate.analyze()`` now use instances of
+  ``ReferencedVariable`` for their keys. ``ReferencedVariable`` is a ``str`` subclass
+  that adds a ``parts`` property, being a tuple representation of the variable.
 
 Version 1.5.1
 -------------

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 # pylint: disable=useless-import-alias,missing-module-docstring
 
-__version__ = "1.5.2"
+__version__ = "1.6.0"
 
 try:
     from markupsafe import escape as escape

--- a/liquid/expression.py
+++ b/liquid/expression.py
@@ -331,6 +331,7 @@ class IdentifierPathElement(Literal[Union[int, str]]):
 
 
 IdentifierPath = List[Union[IdentifierPathElement, "Identifier"]]
+IdentifierTuple = Tuple[Union[str, "IdentifierTuple"], ...]
 
 
 class Identifier(Expression):
@@ -357,6 +358,16 @@ class Identifier(Expression):
                 else:
                     buf.append(str(elem))
         return ".".join(buf).replace(".[", "[")
+
+    def as_tuple(self) -> IdentifierTuple:
+        """Return this identifier's path as a tuple."""
+        parts: List[Union[str, IdentifierTuple]] = []
+        for elem in self.path:
+            if isinstance(elem, Identifier):
+                parts.append(elem.as_tuple())
+            else:
+                parts.append(str(elem))
+        return tuple(parts)
 
     def __hash__(self) -> int:
         return hash(tuple(self.path))

--- a/tests/test_contextual_analysis.py
+++ b/tests/test_contextual_analysis.py
@@ -48,6 +48,16 @@ class ContextualAnalysisTestCase(unittest.TestCase):
 
         self._test(template, data, expect_variables, expect_locals, expect_undefined)
 
+    def test_analyze_output_with_bracketed_properties(self):
+        """Test that we handle bracketed property access with dots."""
+        template = Template("{{ some['foo.bar'].other }}")
+        data = {}
+        expect_variables = {'some["foo.bar"].other': 1}
+        expect_locals = {}
+        expect_undefined = {'some["foo.bar"].other': 1}
+
+        self._test(template, data, expect_variables, expect_locals, expect_undefined)
+
     def test_visit_branches(self):
         """Test that we only count references to variables in visited branches."""
         template = Template(

--- a/tests/test_identifier_as_tuple.py
+++ b/tests/test_identifier_as_tuple.py
@@ -1,0 +1,58 @@
+"""Test cases for representing an Identifier as a tuple."""
+from unittest import TestCase
+
+from liquid.expression import Identifier
+from liquid.expression import IdentifierPathElement
+
+
+class IdentifierAsTupleTestCase(TestCase):
+    """Test cases for representing an Identifier as a tuple."""
+
+    def test_simple_variable(self):
+        """Test that we can represent a simple variable as a tuple."""
+        ident = Identifier(path=[IdentifierPathElement("some")])
+        self.assertEqual(ident.as_tuple(), ("some",))
+
+    def test_dotted_variable(self):
+        """Test that we can represent a dotted variable as a tuple."""
+        ident = Identifier(
+            path=[
+                IdentifierPathElement("some"),
+                IdentifierPathElement("thing"),
+            ]
+        )
+        self.assertEqual(ident.as_tuple(), ("some", "thing"))
+
+    def test_bracketed_variable(self):
+        """Test that we can represent a bracketed variable as a tuple."""
+        ident = Identifier(
+            path=[
+                IdentifierPathElement("some"),
+                IdentifierPathElement("other.thing"),
+            ]
+        )
+        self.assertEqual(ident.as_tuple(), ("some", "other.thing"))
+
+    def test_nested_variable(self):
+        """Test that we can represent nested variables as a tuple."""
+        ident = Identifier(
+            path=[
+                IdentifierPathElement("some"),
+                Identifier(
+                    path=[
+                        IdentifierPathElement("foo"),
+                        IdentifierPathElement("bar"),
+                        Identifier(
+                            path=[
+                                IdentifierPathElement("a"),
+                                IdentifierPathElement("b"),
+                            ]
+                        ),
+                    ]
+                ),
+                IdentifierPathElement("other.thing"),
+            ]
+        )
+        self.assertEqual(
+            ident.as_tuple(), ("some", ("foo", "bar", ("a", "b")), "other.thing")
+        )


### PR DESCRIPTION
This pull requests exposes `liquid.expression.Identifier` objects to `liquid.BoundTemplate.analyze()`, rather than already stringified representations of variables. This gives the template some flexibility as to how to represent variables in analysis results.

To facilitate a tuple representation of a variable's parts, we also add an `as_tuple` method to `liquid.expression.Identifier`.

Closes #87.