### PR TITLE
Analyze template tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,9 @@ Version 1.7.0 (unreleased)
 
 - Fixed counting of "local" variables (those created with ``assign``, ``capture``, etc.)
   in templates rendered with the ``{% render %}`` tag during contextual analysis.
-  Previously these variables were silently ignored.
-  See `#92 <https://github.com/jg-rp/liquid/issues/92>`_
+  Previously these variables were not reported in the results of
+  ``BoundTemplate.analyze_with_context()``.
+  See `#92 <https://github.com/jg-rp/liquid/issues/92>`_.
 
 **Features**
 
@@ -21,7 +22,7 @@ Version 1.7.0 (unreleased)
 - Analyze template tags using ``Environment.analyze_tags()``. This form of tag analysis
   happens before a template is fully parsed, giving us the opportunity to find unknown,
   unexpected and unbalanced tags that might cause the parser to raise an exception or
-  skip template blocks. See `#98 <https://github.com/jg-rp/liquid/pull/98>`_
+  skip template blocks. See `#98 <https://github.com/jg-rp/liquid/pull/98>`_.
 
 Version 1.6.1
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,10 +13,15 @@ Version 1.7.0 (unreleased)
 
 **Features**
 
-- Report filter usage alongside variable usage with static and contextual template
-  analysis. See `#91 <https://github.com/jg-rp/liquid/pull/91>`_.
-- Report tag usage when statically analyzing a template.
-  See `#97 <https://github.com/jg-rp/liquid/pull/97>`_.
+- Report template filter usage as well as variable usage with ``BoundTemplate.analyze()``
+  and ``BoundTemplate.analyze_with_context()``.
+  See `#91 <https://github.com/jg-rp/liquid/pull/91>`_.
+- Report template tag usage when statically analyzing a template with
+  ``BoundTemplate.analyze()``. See `#97 <https://github.com/jg-rp/liquid/pull/97>`_.
+- Analyze template tags using ``Environment.analyze_tags()``. This form of tag analysis
+  happens before a template is fully parsed, giving us the opportunity to find unknown,
+  unexpected and unbalanced tags that might cause the parser to raise an exception or
+  skip template blocks. See `#98 <https://github.com/jg-rp/liquid/pull/98>`_
 
 Version 1.6.1
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,7 +10,7 @@ Rendering Templates
 -------------------
 
 .. autoclass:: Environment([options])
-    :members: from_string, get_template, get_template_async, add_tag, add_filter
+    :members: from_string, get_template, get_template_async, add_tag, add_filter, analyze_tags, analyze_tags_async, analyze_tags_from_string, parse
 
     .. attribute:: context_depth_limit
 
@@ -96,15 +96,22 @@ Rendering Templates
         A dictionary of variables that will be added to the context of every template
         rendered from the environment.
 
+Template Analysis
+-----------------
+
 .. autoclass:: liquid.template.TemplateAnalysis
 
 .. autoclass:: liquid.template.ContextualTemplateAnalysis
+
+.. autoclass:: liquid.analyze_tags.TagAnalysis
 
 
 Template Loaders
 ----------------
 
 .. autoclass:: liquid.loaders.FileSystemLoader
+
+.. autoclass:: liquid.loaders.FileExtensionLoader
 
 .. autoclass:: liquid.loaders.DictLoader
 

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -4,30 +4,57 @@
 __version__ = "1.7.0"
 
 try:
-    from markupsafe import escape as escape
-    from markupsafe import Markup as Markup
+    from markupsafe import escape
+    from markupsafe import Markup
     from markupsafe import soft_str
 except ImportError:
-    from liquid.exceptions import escape as escape  # type: ignore
-    from liquid.exceptions import Markup as Markup  # type: ignore
+    from liquid.exceptions import escape  # type: ignore
+    from liquid.exceptions import Markup  # type: ignore
 
     # pylint: disable=invalid-name
     soft_str = str  # type: ignore
 
-from .mode import Mode as Mode
+from .mode import Mode
 from .token import Token
 from .expression import Expression
 
-from .loaders import FileSystemLoader as FileSystemLoader
-from .loaders import DictLoader as DictLoader
-from .loaders import ChoiceLoader as ChoiceLoader
+from .loaders import ChoiceLoader
+from .loaders import DictLoader
+from .loaders import FileExtensionLoader
+from .loaders import FileSystemLoader
 
-from .context import Context as Context
-from .context import Undefined as Undefined
-from .context import DebugUndefined as DebugUndefined
-from .context import StrictUndefined as StrictUndefined
-from .context import StrictDefaultUndefined as StrictDefaultUndefined
-from .context import is_undefined as is_undefined
+from .context import Context
+from .context import DebugUndefined
+from .context import is_undefined
+from .context import StrictDefaultUndefined
+from .context import StrictUndefined
+from .context import Undefined
 
-from .environment import Environment as Environment
-from .environment import Template as Template
+from .environment import Environment
+from .environment import Template
+
+from .analyze_tags import TagAnalysis
+from .analyze_tags import DEFAULT_INNER_TAG_MAP
+
+__all__ = (
+    "ChoiceLoader",
+    "Context",
+    "DebugUndefined",
+    "DEFAULT_INNER_TAG_MAP",
+    "DictLoader",
+    "Environment",
+    "escape",
+    "Expression",
+    "FileExtensionLoader",
+    "FileSystemLoader",
+    "is_undefined",
+    "Markup",
+    "Mode",
+    "soft_str",
+    "StrictDefaultUndefined",
+    "StrictUndefined",
+    "TagAnalysis",
+    "Template",
+    "Token",
+    "Undefined",
+)

--- a/liquid/analyze_tags.py
+++ b/liquid/analyze_tags.py
@@ -1,4 +1,4 @@
-"""Audit template tags from tokenized source text."""
+"""Analyze template tags from tokenized source text."""
 from __future__ import annotations
 from collections import defaultdict
 
@@ -114,7 +114,9 @@ class TagAnalysis:  # pylint: disable=too-many-instance-attributes too-few-publi
 
         # Infer which tags are block tags. This may or may not match what the
         # environment's tag register believes are block tags.
-        block_tags = {tag[3:] for tag in end_tags}
+        block_tags = {tag[3:] for tag in end_tags} | {
+            tag.name for tag in env.tags.values() if tag.block
+        }
 
         # Registered tags. "break" and "continue" are a special case.
         registered_tags = {
@@ -122,11 +124,11 @@ class TagAnalysis:  # pylint: disable=too-many-instance-attributes too-few-publi
         }
 
         # Registered inline tags. We use this to find erroneous "end" tags.
-        inline_tags = {tag.name for tag in env.tags.values() if tag.block is False}
+        inline_tags = {tag.name for tag in env.tags.values() if not tag.block}
 
         # We use this to find unknown "end" tags.
         registered_end_blocks = {
-            tag.end for tag in env.tags.values() if tag.block is True and tag.end
+            tag.end for tag in env.tags.values() if tag.block and tag.end
         }
 
         for token in tokens:
@@ -199,3 +201,9 @@ class _BlockStackItem:
 
     def __hash__(self) -> int:  # pragma: no cover
         return hash(self.name)
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __repr__(self) -> str:
+        return f"_BlockStackItem({self.name})"

--- a/liquid/analyze_tags.py
+++ b/liquid/analyze_tags.py
@@ -1,0 +1,201 @@
+"""Audit template tags from tokenized source text."""
+from __future__ import annotations
+from collections import defaultdict
+
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Mapping
+from typing import Optional
+from typing import Tuple
+from typing import TYPE_CHECKING
+
+from liquid.token import TOKEN_TAG
+
+if TYPE_CHECKING:  # pragma: no cover
+    from liquid import Environment
+    from liquid.token import Token
+
+
+DEFAULT_INNER_TAG_MAP = {
+    "for": ["break", "continue"],
+    "if": ["else", "elsif"],
+    "case": ["when"],
+    "unless": ["else", "elsif"],
+}
+
+InnerTagMap = Mapping[str, Iterable[str]]
+TagMap = Dict[str, List[Tuple[str, int]]]
+
+
+class TagAnalysis:  # pylint: disable=too-many-instance-attributes too-few-public-methods
+    """The result of analyzing a template's tags with :meth:`Environment.analyze_tags`
+    or :meth:`Environment.analyze_tags_async`.
+
+    Each of the following properties maps tag names to a list of their locations.
+    Locations are (template_name, line_number) tuples.
+
+    Note that ``raw`` tags are not included at all. The lexer converts them to text
+    tokens before we get a chance to analyze them.
+
+    Also be aware that reported `unexpected_tags` don't handle the possibility of an
+    "inner" tag appearing in a partial template (using ``{% include %}``), where
+    appropriate enclosing block tags are in the parent template.
+
+    :ivar all_tags: A mapping of all tags to their locations. Includes "end", "inner"
+        and unknown tags.
+    :ivar tags: A mapping of tag names to their locations. Excludes "end" and "inner"
+        tags.
+    :ivar unclosed_tags: Block tags that don't have a matching "end" tag.
+    :ivar unexpected_tags: Inner tags that are not properly enclosed by appropriate
+        block tags. For example, an ``{% else %}`` that is not enclosed by a
+        ``{% for %}`` or ``{% unless %}`` block.
+    :ivar unknown_tags: Tags that are unknown to the environment.
+    """
+
+    def __init__(
+        self,
+        *,
+        env: Environment,
+        name: str,
+        tokens: List[Token],
+        inner_tags: Optional[InnerTagMap] = None,
+    ) -> None:
+        self.template_name = name
+
+        # A mapping of all tags to their locations. Includes "end" and inner tags.
+        self.all_tags = self._all_tags(tokens)
+
+        # Reverse map of inner tags to possible enclosing block tags.
+        inner_tags = inner_tags or DEFAULT_INNER_TAG_MAP
+        self._inner_tags = defaultdict(set)
+        for tag, inner in inner_tags.items():
+            for inner_tag in inner:
+                self._inner_tags[inner_tag].add(tag)
+
+        # A mapping of tag names to their locations. Excludes inner tags and "end" tags.
+        self.tags = {
+            tag: loc
+            for tag, loc in self.all_tags.items()
+            if not tag.startswith("end") and tag not in self._inner_tags
+        }
+
+        (
+            self.unclosed_tags,
+            self.unexpected_tags,
+            self.unknown_tags,
+        ) = self._audit_tags(env, tokens)
+
+    def _all_tags(self, tokens: List[Token]) -> TagMap:
+        """Map tag names to their locations, similar to `Template.analyze` etc."""
+        tags = defaultdict(list)
+        for token in tokens:
+            if token.type == TOKEN_TAG:
+                tags[token.value].append((self.template_name, token.linenum))
+        return dict(tags)
+
+    def _audit_tags(
+        self,
+        env: Environment,
+        tokens: List[Token],
+    ) -> Tuple[TagMap, TagMap, TagMap]:
+        # pylint: disable=too-many-locals too-many-branches
+        block_stack: List[_BlockStackItem] = []
+        unclosed_tags: TagMap = defaultdict(list)
+        unexpected_tags: TagMap = defaultdict(list)
+        unknown_tags: TagMap = defaultdict(list)
+
+        # Relies on the "end" closing block tag convention.
+        end_tags = {
+            token.value
+            for token in tokens
+            if token.type == TOKEN_TAG and token.value.startswith("end")
+        }
+
+        # Infer which tags are block tags. This may or may not match what the
+        # environment's tag register believes are block tags.
+        block_tags = {tag[3:] for tag in end_tags}
+
+        # Registered tags. "break" and "continue" are a special case.
+        registered_tags = {
+            name for name in env.tags if name not in ("break", "continue")
+        }
+
+        # Registered inline tags. We use this to find erroneous "end" tags.
+        inline_tags = {tag.name for tag in env.tags.values() if tag.block is False}
+
+        # We use this to find unknown "end" tags.
+        registered_end_blocks = {
+            tag.end for tag in env.tags.values() if tag.block is True and tag.end
+        }
+
+        for token in tokens:
+            if token.type != TOKEN_TAG:
+                continue
+
+            tag_name = token.value
+
+            if tag_name in block_tags:
+                block_stack.append(_BlockStackItem(token))
+            elif tag_name in end_tags:
+                start_block_tag = block_stack.pop()
+                if start_block_tag != tag_name[3:]:
+                    # if start_block_tag.name not in inline_tags:
+                    unclosed_tags[start_block_tag.name].append(
+                        (self.template_name, start_block_tag.token.linenum)
+                    )
+                continue
+
+            if tag_name not in registered_tags:
+                # Possible enclosing tags for an inner tag.
+                enclosing_tags: Iterable[str] = self._inner_tags.get(tag_name, [])
+                if not enclosing_tags:
+                    # Not an inner tag for any block.
+                    unknown_tags[tag_name].append((self.template_name, token.linenum))
+                elif not self._valid_inner_tag(
+                    self._inner_tags.get(tag_name, []), block_stack
+                ):
+                    # An inner tag, but not valid for any blocks currently on the stack.
+                    unexpected_tags[tag_name].append(
+                        (self.template_name, token.linenum)
+                    )
+
+        # Catch any unclosed tags.
+        for block in block_stack:
+            unclosed_tags[block.name].append((self.template_name, block.token.linenum))
+
+        # Catch bad "end" tags.
+        for tag_name, locations in self.all_tags.items():
+            if tag_name.startswith("end"):
+                start_tag_name = tag_name[3:]
+                if start_tag_name in inline_tags and start_tag_name not in unknown_tags:
+                    unknown_tags[tag_name].extend(locations)
+                elif (
+                    tag_name not in registered_end_blocks
+                    and start_tag_name not in unknown_tags
+                ):
+                    unknown_tags[tag_name].extend(locations)
+
+        return dict(unclosed_tags), dict(unexpected_tags), dict(unknown_tags)
+
+    def _valid_inner_tag(
+        self, tag_names: Iterable[str], block_stack: List[_BlockStackItem]
+    ) -> bool:
+        for tag_name in tag_names:
+            if tag_name in block_stack:  # type: ignore
+                return True
+        return False
+
+
+class _BlockStackItem:
+    def __init__(self, token: Token) -> None:
+        self.token = token
+        self.name = token.value
+
+    def __eq__(self, __o: object) -> bool:
+        return __o == self.name or (
+            isinstance(__o, _BlockStackItem) and self.name == __o.name
+        )
+
+    def __hash__(self) -> int:  # pragma: no cover
+        return hash(self.name)

--- a/liquid/context.py
+++ b/liquid/context.py
@@ -373,9 +373,9 @@ class StrictDefaultUndefined(StrictUndefined):
 class Context:
     """A template render context.
 
-    A new render context is created automatically each time meth:`BoundTemplate.render`
-    is called, which includes `globals` set on the bound class:`Environment` and
-    class:`BoundTemplate`.
+    A new render context is created automatically each time :meth:`BoundTemplate.render`
+    is called, which includes `globals` set on the bound :class:`liquid.Environment` and
+    :class:`liquid.template.BoundTemplate`.
     """
 
     __slots__ = (

--- a/liquid/environment.py
+++ b/liquid/environment.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 from functools import lru_cache
 from pathlib import Path
 
+from typing import Any
 from typing import Callable
 from typing import ClassVar
 from typing import Dict
-from typing import Any
-from typing import Type
-from typing import Tuple
-from typing import Union
-from typing import Optional
+from typing import Iterator
 from typing import Mapping
 from typing import MutableMapping
+from typing import Optional
+from typing import Type
+from typing import Tuple
 from typing import TYPE_CHECKING
+from typing import Union
 
 import warnings
 
@@ -23,8 +24,10 @@ from liquid.mode import Mode
 from liquid.tag import Tag
 from liquid.template import BoundTemplate
 from liquid.lex import get_lexer
-from liquid.stream import TokenStream
 from liquid.parse import get_parser
+from liquid.stream import TokenStream
+from liquid.analyze_tags import InnerTagMap
+from liquid.analyze_tags import TagAnalysis
 from liquid.utils import LRUCache
 
 from liquid.expressions import parse_boolean_expression
@@ -47,6 +50,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from liquid.expression import FilteredExpression
     from liquid.expression import LoopExpression
     from liquid.context import Context
+    from liquid.token import Token
 
 
 # pylint: disable=too-many-instance-attributes
@@ -242,6 +246,17 @@ class Environment:
             )
         )
 
+    def tokenizer(self) -> Callable[[str], Iterator[Token]]:
+        """Return a tokenizer for this environment."""
+        return get_lexer(
+            self.tag_start_string,
+            self.tag_end_string,
+            self.statement_start_string,
+            self.statement_end_string,
+            self.comment_start_string,
+            self.comment_end_string,
+        )
+
     def add_tag(self, tag: Type[Tag]) -> None:
         """Register a liquid tag with the environment. Built-in tags are registered for
         you automatically with every new :class:`Environment`.
@@ -270,19 +285,10 @@ class Environment:
     def parse(self, source: str) -> ast.ParseTree:
         """Parse the given string as a liquid template.
 
-        More often than not you'll want to use `Environment.from_string` instead.
+        More often than not you'll want to use :meth:`Environment.from_string` instead.
         """
-        tokenize = get_lexer(
-            self.tag_start_string,
-            self.tag_end_string,
-            self.statement_start_string,
-            self.statement_end_string,
-            self.comment_start_string,
-            self.comment_end_string,
-        )
-
         parser = get_parser(self)
-        token_iter = tokenize(source)
+        token_iter = self.tokenizer()(source)
         return parser.parse(TokenStream(token_iter))
 
     # pylint: disable=redefined-builtin
@@ -338,8 +344,8 @@ class Environment:
     ) -> BoundTemplate:
         """Load and parse a template using the configured loader.
 
-        :param name: The template's name. The loader is responsible for interpretting
-            the name.
+        :param name: The template's name. The loader is responsible for interpreting
+            the name. It could be the name of a file or some other identifier.
         :param globals: A mapping of context variables made available every time the
             resulting template is rendered.
         :returns: A parsed template ready to be rendered.
@@ -398,6 +404,106 @@ class Environment:
     ) -> BoundTemplate:
         """An async version of ``get_template_with_context``."""
         return await self.loader.load_with_context_async(context, name, **kwargs)
+
+    def analyze_tags_from_string(
+        self,
+        source: str,
+        name: str = "<string>",
+        *,
+        inner_tags: Optional[InnerTagMap] = None,
+    ) -> TagAnalysis:
+        """Analyze template tags in template source text against those registered with
+        this environment.
+
+        Unlike template static or contextual analysis, a tag audit does not parse the
+        template source text into an AST, nor does it attempt to load partial templates
+        from ``{% include %}`` or `{% render %}` tags.
+
+        :param source: The source text of the template.
+        :type source: str
+        :param name: A name or identifier for the template. Defaults to "<string>".
+        :type name: str
+        :param inner_tags: A mapping of block tags to a list of allowed "inner" tags for
+            the block. For example, ``{% if %}`` blocks are allowed to contain
+            ``{% elsif %}`` and ``{% else %}`` tags.
+        :type inner_tags: Mapping[str, Iterable[str]]
+        :returns: A tag audit including the location of any unknown tags and any
+            unbalanced block tags.
+        :rtype: :class:`liquid.analyze_tags.TagAnalysis`
+        """
+        return TagAnalysis(
+            env=self,
+            name=name,
+            tokens=list(self.tokenizer()(source)),
+            inner_tags=inner_tags,
+        )
+
+    def analyze_tags(
+        self,
+        name: str,
+        *,
+        context: Optional["Context"] = None,
+        inner_tags: Optional[InnerTagMap] = None,
+        **kwargs: str,
+    ) -> TagAnalysis:
+        """Audit template tags without parsing source text into an abstract syntax tree.
+
+        This is useful for identifying unknown, misplaced and unbalanced tags in a
+        template's source text. See also :meth:`liquid.template.BoundTemplate.analyze`.
+
+        :param name: The template's name or identifier, as you would use with
+            :meth:`Environment.get_template`. Use :meth:`Environment.analyze_tags_from_string`
+            to audit tags in template text without using a template loader.
+        :type name: str
+        :param context: An optional render context the loader might use to modify the
+            template search space. If given, uses
+            :meth:`liquid.loaders.BaseLoader.get_source_with_context` from the current
+            loader if a render context is given.
+        :type context: Optional[:class:`liquid.Context`]
+        :param inner_tags: A mapping of block tags to a list of allowed "inner" tags for
+            the block. For example, ``{% if %}`` blocks are allowed to contain
+            ``{% elsif %}`` and ``{% else %}`` tags.
+        :type inner_tags: Mapping[str, Iterable[str]]
+        :returns: A tag audit including the location of any unknown tags and any
+            unbalanced block tags.
+        :rtype: :class:`liquid.analyze_tags.TagAnalysis`
+        """
+        if context:
+            template_source = self.loader.get_source_with_context(
+                context=context, template_name=name, **kwargs
+            )
+        else:
+            template_source = self.loader.get_source(self, template_name=name)
+
+        return self.analyze_tags_from_string(
+            template_source.source,
+            name=template_source.filename,
+            inner_tags=inner_tags,
+        )
+
+    async def analyze_tags_async(
+        self,
+        name: str,
+        *,
+        context: Optional["Context"] = None,
+        inner_tags: Optional[InnerTagMap] = None,
+        **kwargs: str,
+    ) -> TagAnalysis:
+        """An async version of :meth:`Environment.analyze_tags`."""
+        if context:
+            template_source = await self.loader.get_source_with_context_async(
+                context=context, template_name=name, **kwargs
+            )
+        else:
+            template_source = await self.loader.get_source_async(
+                env=self, template_name=name
+            )
+
+        return self.analyze_tags_from_string(
+            template_source.source,
+            name=template_source.filename,
+            inner_tags=inner_tags,
+        )
 
     def _check_cache(
         self,
@@ -617,6 +723,7 @@ def Template(
     :param globals: An optional mapping that will be added to the context of any
         template loaded from this environment. Defaults to ``None``.
     :type globals: dict
+    :rtype: BoundTemplate
     """
     # Resorting to named arguments (repeated 3 times) as I've twice missed a bug
     # because of positional arguments.

--- a/liquid/environment.py
+++ b/liquid/environment.py
@@ -412,8 +412,8 @@ class Environment:
         *,
         inner_tags: Optional[InnerTagMap] = None,
     ) -> TagAnalysis:
-        """Analyze template tags in template source text against those registered with
-        this environment.
+        """Analyze tags in template source text against those registered with this
+        environment.
 
         Unlike template static or contextual analysis, a tag audit does not parse the
         template source text into an AST, nor does it attempt to load partial templates
@@ -458,7 +458,7 @@ class Environment:
         :param context: An optional render context the loader might use to modify the
             template search space. If given, uses
             :meth:`liquid.loaders.BaseLoader.get_source_with_context` from the current
-            loader if a render context is given.
+            loader.
         :type context: Optional[:class:`liquid.Context`]
         :param inner_tags: A mapping of block tags to a list of allowed "inner" tags for
             the block. For example, ``{% if %}`` blocks are allowed to contain

--- a/liquid/template.py
+++ b/liquid/template.py
@@ -487,7 +487,7 @@ NameRefs = Dict[str, List[Location]]
 
 # pylint: disable=too-few-public-methods
 class ContextualTemplateAnalysis:
-    """The result of analyzing a template's variables using
+    """The result of analyzing a template's filters and variables using
     :meth:`BoundTemplate.analyze_with_context`.
 
     Each of the following properties is a dictionary mapping variable or filter names
@@ -522,7 +522,7 @@ class ContextualTemplateAnalysis:
 
 # pylint: disable=too-few-public-methods
 class TemplateAnalysis:
-    """The result of analyzing a template's variables using
+    """The result of analyzing a template's tags, filters and variables using
     :meth:`BoundTemplate.analyze`.
 
     Each of the following properties is a dictionary mapping variable, tag or filter

--- a/tests/test_analyze_template.py
+++ b/tests/test_analyze_template.py
@@ -1,4 +1,4 @@
-"""Test cases for statically counting a template's variables."""
+"""Test cases for statically counting a template using `BoundTemplate.analyze`."""
 # pylint: disable=too-many-lines
 import asyncio
 

--- a/tests/test_analyze_template_tags.py
+++ b/tests/test_analyze_template_tags.py
@@ -92,6 +92,22 @@ class AnalyzeTagsTestCase(TestCase):
                 unclosed_tags={"if": [("<string>", 1)]},
             ),
             Case(
+                description="unbalanced block tag without inferred end tag",
+                source=(
+                    "{% for foo in bar %}\n"
+                    "{% if foo %}\n"
+                    "    {{ foo | upcase }}\n"
+                    "{% endif %}"
+                ),
+                all_tags={
+                    "for": [("<string>", 1)],
+                    "if": [("<string>", 2)],
+                    "endif": [("<string>", 4)],
+                },
+                tags={"if": [("<string>", 2)], "for": [("<string>", 1)]},
+                unclosed_tags={"for": [("<string>", 1)]},
+            ),
+            Case(
                 description="end block typo",
                 source="{% if foo %}{% if bar %}{% endif %}\n{% endi %}",
                 all_tags={

--- a/tests/test_analyze_template_tags.py
+++ b/tests/test_analyze_template_tags.py
@@ -1,0 +1,279 @@
+"""Test cases for analyzing a template's tags using `Environment.analyze_tags`."""
+import asyncio
+from dataclasses import dataclass
+from dataclasses import field
+from typing import List
+from unittest import TestCase
+
+from liquid import Environment
+from liquid import DictLoader
+from liquid.analyze_tags import TagAnalysis
+from liquid.analyze_tags import TagMap
+from liquid.context import Context
+from liquid.extra.tags import WithTag
+
+
+@dataclass
+class Case:
+    """Table-driven test case helper."""
+
+    description: str
+    source: str
+    all_tags: TagMap = field(default_factory=dict)
+    tags: TagMap = field(default_factory=dict)
+    unclosed_tags: TagMap = field(default_factory=dict)
+    unexpected_tags: TagMap = field(default_factory=dict)
+    unknown_tags: TagMap = field(default_factory=dict)
+
+
+class AnalyzeTagsTestCase(TestCase):
+    """Test cases for analyzing a template's tags using `Environment.analyze_tags`."""
+
+    def setUp(self) -> None:
+        self.standard_env = Environment()
+
+    def _test(self, env: Environment, test_cases: List[Case]) -> None:
+        """Test helper function."""
+        for case in test_cases:
+            with self.subTest(msg=case.description):
+                tag_analysis = env.analyze_tags_from_string(case.source)
+                self.assertEqual(tag_analysis.all_tags, case.all_tags)
+                self.assertEqual(tag_analysis.tags, case.tags)
+                self.assertEqual(tag_analysis.unclosed_tags, case.unclosed_tags)
+                self.assertEqual(tag_analysis.unexpected_tags, case.unexpected_tags)
+                self.assertEqual(tag_analysis.unknown_tags, case.unknown_tags)
+
+    def test_analyze_tags(self) -> None:
+        """Test that we can analyze a template's tags."""
+        test_cases = [
+            Case(description="no tags", source="hello"),
+            Case(
+                description="inline tag",
+                source="{% assign foo = 'bar' %}",
+                all_tags={"assign": [("<string>", 1)]},
+                tags={"assign": [("<string>", 1)]},
+            ),
+            Case(
+                description="one block tag",
+                source="{% if foo %}{% endif %}",
+                all_tags={
+                    "if": [("<string>", 1)],
+                    "endif": [("<string>", 1)],
+                },
+                tags={"if": [("<string>", 1)]},
+            ),
+            Case(
+                description="two block tags",
+                source="{% if foo %}{% endif %}\n{% if bar %}{% endif %}",
+                all_tags={
+                    "if": [("<string>", 1), ("<string>", 2)],
+                    "endif": [("<string>", 1), ("<string>", 2)],
+                },
+                tags={"if": [("<string>", 1), ("<string>", 2)]},
+            ),
+            Case(
+                description="unknown block tag",
+                source="{% form foo %}{% endform %}",
+                all_tags={
+                    "form": [("<string>", 1)],
+                    "endform": [("<string>", 1)],
+                },
+                tags={"form": [("<string>", 1)]},
+                unknown_tags={"form": [("<string>", 1)]},
+            ),
+            Case(
+                description="unbalanced block tag",
+                source="{% if foo %}{% if bar %}{% endif %}\n{% if baz %}{% endif %}",
+                all_tags={
+                    "if": [("<string>", 1), ("<string>", 1), ("<string>", 2)],
+                    "endif": [("<string>", 1), ("<string>", 2)],
+                },
+                tags={"if": [("<string>", 1), ("<string>", 1), ("<string>", 2)]},
+                unclosed_tags={"if": [("<string>", 1)]},
+            ),
+            Case(
+                description="end block typo",
+                source="{% if foo %}{% if bar %}{% endif %}\n{% endi %}",
+                all_tags={
+                    "if": [("<string>", 1), ("<string>", 1)],
+                    "endif": [("<string>", 1)],
+                    "endi": [("<string>", 2)],
+                },
+                tags={"if": [("<string>", 1), ("<string>", 1)]},
+                unclosed_tags={"if": [("<string>", 1)]},
+                unknown_tags={"endi": [("<string>", 2)]},
+            ),
+            Case(
+                description="end block with wrong name",
+                source="{% if foo %}{% if bar %}{% endif %}\n{% endfor %}",
+                all_tags={
+                    "if": [("<string>", 1), ("<string>", 1)],
+                    "endif": [("<string>", 1)],
+                    "endfor": [("<string>", 2)],
+                },
+                tags={"if": [("<string>", 1), ("<string>", 1)]},
+                unclosed_tags={"if": [("<string>", 1)]},
+            ),
+            Case(
+                description="unexpected closing of inline tag",
+                source="{% increment foo %}{% endincrement %}",
+                all_tags={
+                    "increment": [("<string>", 1)],
+                    "endincrement": [("<string>", 1)],
+                },
+                tags={"increment": [("<string>", 1)]},
+                unknown_tags={"endincrement": [("<string>", 1)]},
+            ),
+            Case(
+                description="inner tag",
+                source="{% if foo %}{% else %}{% endif %}",
+                all_tags={
+                    "if": [("<string>", 1)],
+                    "else": [("<string>", 1)],
+                    "endif": [("<string>", 1)],
+                },
+                tags={"if": [("<string>", 1)]},
+            ),
+            Case(
+                description="inner break tag",
+                source="{% for foo in bar %}{% break %}{% endfor %}",
+                all_tags={
+                    "for": [("<string>", 1)],
+                    "break": [("<string>", 1)],
+                    "endfor": [("<string>", 1)],
+                },
+                tags={"for": [("<string>", 1)]},
+            ),
+            Case(
+                description="inner continue tag",
+                source="{% for foo in bar %}{% continue %}{% endfor %}",
+                all_tags={
+                    "for": [("<string>", 1)],
+                    "continue": [("<string>", 1)],
+                    "endfor": [("<string>", 1)],
+                },
+                tags={"for": [("<string>", 1)]},
+            ),
+            Case(
+                description="orphaned inner tag",
+                source="{% if foo %}{% endif %}{% else %}",
+                all_tags={
+                    "if": [("<string>", 1)],
+                    "else": [("<string>", 1)],
+                    "endif": [("<string>", 1)],
+                },
+                tags={"if": [("<string>", 1)]},
+                unexpected_tags={"else": [("<string>", 1)]},
+            ),
+            Case(
+                description="orphaned break tag",
+                source="{% for foo in bar %}{% endfor %}{% break %}",
+                all_tags={
+                    "for": [("<string>", 1)],
+                    "break": [("<string>", 1)],
+                    "endfor": [("<string>", 1)],
+                },
+                tags={"for": [("<string>", 1)]},
+                unexpected_tags={"break": [("<string>", 1)]},
+            ),
+            Case(
+                description="orphaned continue tag",
+                source="{% for foo in bar %}{% endfor %}{% continue %}",
+                all_tags={
+                    "for": [("<string>", 1)],
+                    "continue": [("<string>", 1)],
+                    "endfor": [("<string>", 1)],
+                },
+                tags={"for": [("<string>", 1)]},
+                unexpected_tags={"continue": [("<string>", 1)]},
+            ),
+        ]
+
+        self._test(self.standard_env, test_cases)
+
+    def test_analyze_tags_with_loader(self) -> None:
+        """Test the `Environment.analyze_tags` method."""
+        case = Case(
+            description="",
+            source="{% for foo in bar %}{% if foo %}\n{% endif %}{% endfor %}",
+            all_tags={
+                "if": [("some.liquid", 1)],
+                "for": [("some.liquid", 1)],
+                "endif": [("some.liquid", 2)],
+                "endfor": [("some.liquid", 2)],
+            },
+            tags={"if": [("some.liquid", 1)], "for": [("some.liquid", 1)]},
+        )
+
+        loader = DictLoader({"some.liquid": case.source})
+        env = Environment(loader=loader)
+
+        async def coro():
+            return await env.analyze_tags_async("some.liquid")
+
+        def assert_tags(tag_analysis: TagAnalysis) -> None:
+            self.assertEqual(tag_analysis.all_tags, case.all_tags)
+            self.assertEqual(tag_analysis.tags, case.tags)
+            self.assertEqual(tag_analysis.unclosed_tags, case.unclosed_tags)
+            self.assertEqual(tag_analysis.unexpected_tags, case.unexpected_tags)
+            self.assertEqual(tag_analysis.unknown_tags, case.unknown_tags)
+
+        assert_tags(env.analyze_tags("some.liquid"))
+
+        with self.subTest(msg="async"):
+            assert_tags(asyncio.run(coro()))
+
+    def test_analyze_tags_with_loader_context(self) -> None:
+        """Test the `Environment.analyze_tags` method with context."""
+        case = Case(
+            description="",
+            source="{% for foo in bar %}{% if foo %}\n{% endif %}{% endfor %}",
+            all_tags={
+                "if": [("some.liquid", 1)],
+                "for": [("some.liquid", 1)],
+                "endif": [("some.liquid", 2)],
+                "endfor": [("some.liquid", 2)],
+            },
+            tags={"if": [("some.liquid", 1)], "for": [("some.liquid", 1)]},
+        )
+
+        loader = DictLoader({"some.liquid": case.source})
+        env = Environment(loader=loader)
+        context = Context(env)
+
+        async def coro():
+            return await env.analyze_tags_async("some.liquid", context=context)
+
+        def assert_tags(tag_analysis: TagAnalysis) -> None:
+            self.assertEqual(tag_analysis.all_tags, case.all_tags)
+            self.assertEqual(tag_analysis.tags, case.tags)
+            self.assertEqual(tag_analysis.unclosed_tags, case.unclosed_tags)
+            self.assertEqual(tag_analysis.unexpected_tags, case.unexpected_tags)
+            self.assertEqual(tag_analysis.unknown_tags, case.unknown_tags)
+
+        assert_tags(env.analyze_tags("some.liquid", context=context))
+
+        with self.subTest(msg="async"):
+            assert_tags(asyncio.run(coro()))
+
+    def test_analyze_tags_with_extra_tag(self) -> None:
+        """Test analyze non-standard, extra tag."""
+        case = Case(
+            description="",
+            source="{% with foo:bar %}{% endwith %}",
+            all_tags={
+                "with": [("<string>", 1)],
+                "endwith": [("<string>", 1)],
+            },
+            tags={"with": [("<string>", 1)]},
+        )
+
+        env = Environment()
+        env.add_tag(WithTag)
+
+        tag_analysis = env.analyze_tags_from_string(case.source)
+        self.assertEqual(tag_analysis.all_tags, case.all_tags)
+        self.assertEqual(tag_analysis.tags, case.tags)
+        self.assertEqual(tag_analysis.unclosed_tags, case.unclosed_tags)
+        self.assertEqual(tag_analysis.unexpected_tags, case.unexpected_tags)
+        self.assertEqual(tag_analysis.unknown_tags, case.unknown_tags)


### PR DESCRIPTION
This pull request adds `analyze_tags`, `analyze_tags_async` and `analyze_tags_from_string` methods to `liquid.Environment`. Each of these methods inspects tokens from template source text and returns an instance of `liquid.TagAnalysis`,  without constructing an abstract syntax tree. This is useful for identifying unknown, misplaced and unbalanced tags before attempting to parse source text into a `liquid.BoundTemplate`.

Closes #95.

`TagAnalysis` objects include several useful properties, each of which is a mapping of tag names to a list of `(template_name, line_number)` tuples, one tuple for each occurrence of the tag.

This example analyzes tags in `article.liquid` from the [tribble test fixture](https://github.com/jg-rp/liquid/tree/main/tests/fixtures/tribble).

```python
from pprint import pprint

from liquid import Environment
from liquid import FileSystemLoader

env = Environment(loader=FileSystemLoader("tests/fixtures/"))
tag_analysis = env.analyze_tags("tribble/article.liquid")

print("tag_analysis.tags:")
pprint(tag_analysis.tags)

print("\ntag_analysis.all_tags:")
pprint(tag_analysis.all_tags)

print("\ntag_analysis.unknown_tags:")
pprint(tag_analysis.unknown_tags)
```

**output**
```plain
tag_analysis.tags:
{'for': [('tests/fixtures/tribble/article.liquid', 19)],
 'form': [('tests/fixtures/tribble/article.liquid', 34)],
 'if': [('tests/fixtures/tribble/article.liquid', 13),
        ('tests/fixtures/tribble/article.liquid', 38),
        ('tests/fixtures/tribble/article.liquid', 39),
        ('tests/fixtures/tribble/article.liquid', 49),
        ('tests/fixtures/tribble/article.liquid', 54),
        ('tests/fixtures/tribble/article.liquid', 55),
        ('tests/fixtures/tribble/article.liquid', 57),
        ('tests/fixtures/tribble/article.liquid', 58),
        ('tests/fixtures/tribble/article.liquid', 60),
        ('tests/fixtures/tribble/article.liquid', 61),
        ('tests/fixtures/tribble/article.liquid', 64)]}

tag_analysis.all_tags:
{'else': [('tests/fixtures/tribble/article.liquid', 44)],
 'endfor': [('tests/fixtures/tribble/article.liquid', 29)],
 'endform': [('tests/fixtures/tribble/article.liquid', 69)],
 'endif': [('tests/fixtures/tribble/article.liquid', 46),
           ('tests/fixtures/tribble/article.liquid', 47),
           ('tests/fixtures/tribble/article.liquid', 51),
           ('tests/fixtures/tribble/article.liquid', 54),
           ('tests/fixtures/tribble/article.liquid', 55),
           ('tests/fixtures/tribble/article.liquid', 57),
           ('tests/fixtures/tribble/article.liquid', 58),
           ('tests/fixtures/tribble/article.liquid', 60),
           ('tests/fixtures/tribble/article.liquid', 61),
           ('tests/fixtures/tribble/article.liquid', 66),
           ('tests/fixtures/tribble/article.liquid', 74)],
 'for': [('tests/fixtures/tribble/article.liquid', 19)],
 'form': [('tests/fixtures/tribble/article.liquid', 34)],
 'if': [('tests/fixtures/tribble/article.liquid', 13),
        ('tests/fixtures/tribble/article.liquid', 38),
        ('tests/fixtures/tribble/article.liquid', 39),
        ('tests/fixtures/tribble/article.liquid', 49),
        ('tests/fixtures/tribble/article.liquid', 54),
        ('tests/fixtures/tribble/article.liquid', 55),
        ('tests/fixtures/tribble/article.liquid', 57),
        ('tests/fixtures/tribble/article.liquid', 58),
        ('tests/fixtures/tribble/article.liquid', 60),
        ('tests/fixtures/tribble/article.liquid', 61),
        ('tests/fixtures/tribble/article.liquid', 64)]}

tag_analysis.unknown_tags:
{'form': [('tests/fixtures/tribble/article.liquid', 34)]}
```

If a template's source text contains unbalanced block tags, those tags will appear in `TagAnalysis.unclosed_tags`.

```python
from pprint import pprint
from liquid import Environment

env = Environment()

tag_analysis = env.analyze_tags_from_string("""\
{% for foo in bar %}
{% if foo %}
    {{ foo | upcase }}
{% endif %}
""")

pprint(tag_analysis.unclosed_tags)
# {'for': [('<string>', 1)]}
```

Tags that are not registered with the environment will appear in `TagAnalysis.unknown_tags`.

```python
from pprint import pprint
from liquid import Environment

env = Environment()

tag_analysis = env.analyze_tags_from_string("""\
{% form article %}
  <h2>Leave a comment</h2>
  <input type="submit" value="Post comment" id="comment-submit" />
{% endform %}
""")

pprint(tag_analysis.unknown_tags)
# {'form': [('<string>', 1)]}
```

If an "inner" tag - like `elsif` and `else` for `if` and `unless` tags - appear without an appropriate enclosing block, those tags will appear in `TagAnalysis.unexpected_tags`.

```python
from pprint import pprint
from liquid import Environment

env = Environment()

tag_analysis = env.analyze_tags_from_string("""\
{% for foo in bar %}
  {{ foo }}
{% endfor %}
{% break %}
""")

pprint(tag_analysis.unexpected_tags)
# {'break': [('<string>', 4)]}
```