### PR TITLE
sort_numeric filter

### DIFF
--- a/liquid/extra/__init__.py
+++ b/liquid/extra/__init__.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from .filters import index
 from .filters import JSON
 from .filters import script_tag
+from .filters import sort_numeric
 from .filters import stylesheet_tag
 
 from .tags import CallTag
@@ -23,26 +24,27 @@ if TYPE_CHECKING:  # pragma: no cover
     from liquid import Environment
 
 __all__ = (
-    "index",
-    "JSON",
-    "script_tag",
-    "stylesheet_tag",
+    "add_extended_inline_expression_tags",
+    "add_filters",
+    "add_inline_expression_tags",
+    "add_macro_tags",
+    "add_tags_and_filters",
+    "add_tags",
     "CallTag",
     "IfNotTag",
+    "index",
     "InlineIfAssignTag",
     "InlineIfAssignTagWithParens",
     "InlineIfEchoTag",
     "InlineIfEchoTagWithParens",
     "InlineIfStatement",
     "InlineIfStatementWithParens",
+    "JSON",
     "MacroTag",
+    "script_tag",
+    "sort_numeric",
+    "stylesheet_tag",
     "WithTag",
-    "add_filters",
-    "add_inline_expression_tags",
-    "add_extended_inline_expression_tags",
-    "add_macro_tags",
-    "add_tags",
-    "add_tags_and_filters",
 )
 
 
@@ -84,6 +86,7 @@ def add_filters(env: Environment) -> None:
     env.add_filter("index", index)
     env.add_filter("json", JSON())
     env.add_filter("script_tag", script_tag)
+    env.add_filter("sort_numeric", sort_numeric)
     env.add_filter("stylesheet_tag", stylesheet_tag)
 
 

--- a/liquid/extra/filters/__init__.py
+++ b/liquid/extra/filters/__init__.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-module-docstring
 from .array import index
+from .array import sort_numeric
 from .html import script_tag
 from .html import stylesheet_tag
 from ._json import JSON
@@ -9,5 +10,6 @@ __all__ = (
     "index",
     "JSON",
     "script_tag",
+    "sort_numeric",
     "stylesheet_tag",
 )

--- a/liquid/extra/filters/array.py
+++ b/liquid/extra/filters/array.py
@@ -1,6 +1,20 @@
 """Extra array filters."""
+import math
+import re
+
+from decimal import Decimal
+from operator import getitem
+
+from typing import Any
+from typing import List
 from typing import Sequence
+from typing import Tuple
+from typing import Union
+
 from liquid.filter import array_filter
+from liquid.filter import sequence_filter
+
+from liquid.limits import to_int
 
 
 @array_filter
@@ -12,3 +26,39 @@ def index(left: Sequence[object], obj: object) -> object:
         return left.index(obj)
     except ValueError:
         return None
+
+
+RE_NUMERIC = re.compile(r"-?\d+")
+
+
+@sequence_filter
+def sort_numeric(left: Sequence[object], key: object = None) -> List[object]:
+    """Return a copy of the input sequence sorted by any numeric values found in
+    the sequence's items."""
+    if key:
+        _key = str(key)
+        return sorted(left, key=lambda item: _ints(_getitem(item, _key)))
+    return sorted(left, key=_ints)
+
+
+def _getitem(sequence: Any, key: object, default: object = None) -> Any:
+    """Item getter for the ``sort_numeric`` filter."""
+    try:
+        return getitem(sequence, key)
+    except (KeyError, IndexError, TypeError):
+        return default
+
+
+def _ints(obj: object) -> Tuple[Union[int, float, Decimal], ...]:
+    """Key function for the ``sort_numeric`` filter."""
+    if isinstance(obj, bool):
+        # isinstance(False, int) == True
+        return (math.inf,)
+    if isinstance(obj, (int, float, Decimal)):
+        return (obj,)
+
+    ints = tuple(to_int(n) for n in RE_NUMERIC.findall(str(obj)))
+
+    if not ints:
+        return (math.inf,)
+    return ints

--- a/tests/filters/test_array.py
+++ b/tests/filters/test_array.py
@@ -34,6 +34,7 @@ from liquid.builtin.filters.array import uniq
 from liquid.builtin.filters.array import compact
 
 from liquid.extra.filters.array import index
+from liquid.extra.filters.array import sort_numeric
 
 
 class Case(NamedTuple):
@@ -754,3 +755,143 @@ class ArrayFilterTestCase(unittest.TestCase):
         ]
 
         self._test(index, test_cases)
+
+    def test_sort_numeric(self):
+        """Test the extra `sort_numeric` filter function."""
+        test_cases = [
+            Case(
+                description="list of string ints",
+                val=["10", "3", "2", "1"],
+                args=[],
+                kwargs={},
+                expect=["1", "2", "3", "10"],
+            ),
+            Case(
+                description="list of ints",
+                val=[10, 3, 2, 1],
+                args=[],
+                kwargs={},
+                expect=[1, 2, 3, 10],
+            ),
+            Case(
+                description="list of floats",
+                val=[10.1, 3.5, 2.3, 1.1, 1.01],
+                args=[],
+                kwargs={},
+                expect=[1.01, 1.1, 2.3, 3.5, 10.1],
+            ),
+            Case(
+                description="negative string ints",
+                val=["1", "-1"],
+                args=[],
+                kwargs={},
+                expect=["-1", "1"],
+            ),
+            Case(
+                description="empty list",
+                val=[],
+                args=[],
+                kwargs={},
+                expect=[],
+            ),
+            Case(
+                description="string input",
+                val="12345",
+                args=[],
+                kwargs={},
+                expect=["12345"],
+            ),
+            Case(
+                description="not a sequence",
+                val=None,
+                args=[],
+                kwargs={},
+                expect=[None],
+            ),
+            Case(
+                description="empty list with key argument",
+                val=[],
+                args=["x"],
+                kwargs={},
+                expect=[],
+            ),
+            Case(
+                description="tuple of ints",
+                val=(10, 3, 2, 1),
+                args=[],
+                kwargs={},
+                expect=[1, 2, 3, 10],
+            ),
+            Case(
+                description="list of dicts without a key argument",
+                val=[{"y": "-1", "x": "10"}, {"x": "3"}, {"x": "2"}, {"x": "1"}],
+                args=[],
+                kwargs={},
+                expect=[{"y": "-1", "x": "10"}, {"x": "1"}, {"x": "2"}, {"x": "3"}],
+            ),
+            Case(
+                description="list of dicts with string int values",
+                val=[{"y": "-1", "x": "10"}, {"x": "3"}, {"x": "2"}, {"x": "1"}],
+                args=["x"],
+                kwargs={},
+                expect=[{"x": "1"}, {"x": "2"}, {"x": "3"}, {"y": "-1", "x": "10"}],
+            ),
+            Case(
+                description="dotted with leading non-digit characters",
+                val=["v1.2", "v1.9", "v10.0", "v1.10", "v1.1.0"],
+                args=[],
+                kwargs={},
+                expect=["v1.1.0", "v1.2", "v1.9", "v1.10", "v10.0"],
+            ),
+            Case(
+                description="leading zeros",
+                val=["107", "042", "0001", "02", "17"],
+                args=[],
+                kwargs={},
+                expect=["0001", "02", "17", "042", "107"],
+            ),
+            Case(
+                description="trailing non-digits",
+                val=["42 Some Street", "7 Some Street", "101 Some Street"],
+                args=[],
+                kwargs={},
+                expect=["7 Some Street", "42 Some Street", "101 Some Street"],
+            ),
+            Case(
+                description="too many arguments",
+                val=["1", "2"],
+                args=["x", "y"],
+                kwargs={},
+                expect=FilterArgumentError,
+            ),
+            Case(
+                description="key argument and non-mapping input",
+                val=["2", "1"],
+                args=["x"],
+                kwargs={},
+                expect=["2", "1"],
+            ),
+            Case(
+                description="input containing booleans",
+                val=["2", True, "1"],
+                args=[],
+                kwargs={},
+                expect=["1", "2", True],
+            ),
+            Case(
+                description="list of dicts with some missing keys",
+                val=[{"y": "-1", "x": "10"}, {"x": "3"}, {"x": "2"}, {"y": "1"}],
+                args=["x"],
+                kwargs={},
+                expect=[{"x": "2"}, {"x": "3"}, {"y": "-1", "x": "10"}, {"y": "1"}],
+            ),
+            Case(
+                description="list containing non sequence amongst dicts",
+                val=[{"y": "-1", "x": "10"}, {"x": "3"}, {"x": "2"}, None],
+                args=["x"],
+                kwargs={},
+                expect=[{"x": "2"}, {"x": "3"}, {"y": "-1", "x": "10"}, None],
+            ),
+        ]
+
+        self._test(sort_numeric, test_cases)


### PR DESCRIPTION
This pull request implements a non-standard `sort_numeric` filter, available as `liquid.extra.filters.sort_numeric`.

`<sequence> | sort_numeric[: <string>]`

`sort_numeric` returns a new list with items from the input sequence sorted by any integers and/or floats found in the string representation of each item. Note the difference between `sort_numeric` and `sort` in this example.

```liquid
{% assign foo = '1.2.1, v1.10.0, v1.1.0, v1.2.2' | split: ', ' -%}
{{ foo | sort_numeric | join: ', ' }}
{{ foo | sort | join: ', ' }}

{% assign bar = '107, 12, 0001' | split: ', ' -%}
{{ bar | sort_numeric | join: ', ' }}
{{ bar | sort | join: ', ' }}
```
**Output:**
```plain
v1.1.0, 1.2.1, v1.2.2, v1.10.0
1.2.1, v1.1.0, v1.10.0, v1.2.2

0001, 12, 107
0001, 107, 12
```

The optional string argument is the name of a key/property to use as the sort key. In which case each item in the input sequence should be a dict (or any mapping), each with said key/property.

`sort_numeric` will work as expected when given lists/tuples of integers, floats and/or Decimals, but will be slower than using standard `sort`.

If an input sequence contains strings (or arbitrary objects that get stringified) that do not have numeric characters, they will be pushed to the end of the resulting list, probably in the same order as in the input sequence.
