### PR TITLE
Scoped template loader bootstrapping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Python Liquid Change Log
 ========================
 
-Version 1.8.2 (unreleased)
+Version 1.9.0 (unreleased)
 --------------------------
 
 **Fixes**
@@ -10,6 +10,11 @@ Version 1.8.2 (unreleased)
   See `#107 <https://github.com/jg-rp/liquid/issues/107>`_.
 - Fixed the ``liquid.Environment`` template cache. Now, when given a ``cache_size`` of
   ``0``, the cache is disabled. See `#108 <https://github.com/jg-rp/liquid/issues/108>`_.
+
+**Features**
+
+- Added context-aware template loader bootstrapping methods.
+  See `#109 <https://github.com/jg-rp/liquid/pull/109>`_.
 
 Version 1.8.1
 -------------

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 # pylint: disable=missing-module-docstring
 
-__version__ = "1.8.2"
+__version__ = "1.9.0"
 
 try:
     from markupsafe import escape

--- a/liquid/builtin/filters/array.py
+++ b/liquid/builtin/filters/array.py
@@ -34,7 +34,7 @@ from liquid.undefined import is_undefined
 if TYPE_CHECKING:
     from liquid import Environment
 
-ArrayT = Union[List[Any], Tuple[Any, ...]]
+ArrayT = Union[List[Any], Tuple[Any, ...]]  # pylint: disable=invalid-name
 
 # Send objects with missing keys to the end when sorting a list.
 MAX_CH = chr(0x10FFFF)

--- a/liquid/builtin/filters/math.py
+++ b/liquid/builtin/filters/math.py
@@ -12,8 +12,8 @@ from liquid.exceptions import FilterArgumentError
 from liquid.filter import math_filter
 from liquid.filter import num_arg
 
-DecimalT = decimal.Decimal
-NumberT = Union[float, int]
+DecimalT = decimal.Decimal  # pylint: disable=invalid-name
+NumberT = Union[float, int]  # pylint: disable=invalid-name
 
 
 @math_filter

--- a/liquid/environment.py
+++ b/liquid/environment.py
@@ -389,6 +389,29 @@ class Environment:
             self.cache[name] = template
         return template
 
+    def get_template_with_args(
+        self,
+        name: str,
+        globals: Optional[Mapping[str, object]] = None,
+        **kwargs: object,
+    ) -> BoundTemplate:
+        """Load and parse a template using the configured loader, optionally
+        passing arbitrary keyword arguments to the loader.
+
+        This method bypasses the environment's template cache. You should use a caching
+        loader instead when the loader required extra keyword arguments.
+        """
+        return self.loader.load_with_args(self, name, globals, **kwargs)
+
+    async def get_template_with_args_async(
+        self,
+        name: str,
+        globals: Optional[Mapping[str, object]] = None,
+        **kwargs: object,
+    ) -> BoundTemplate:
+        """An async version of :meth:`get_template_with_args`."""
+        return await self.loader.load_with_args_async(self, name, globals, **kwargs)
+
     def get_template_with_context(
         self,
         context: "Context",
@@ -407,7 +430,7 @@ class Environment:
         name: str,
         **kwargs: str,
     ) -> BoundTemplate:
-        """An async version of ``get_template_with_context``."""
+        """An async version of :meth:`get_template_with_context`."""
         return await self.loader.load_with_context_async(context, name, **kwargs)
 
     def analyze_tags_from_string(

--- a/liquid/filter.py
+++ b/liquid/filter.py
@@ -21,8 +21,8 @@ from liquid.exceptions import FilterValueError
 from liquid.limits import to_int
 
 if TYPE_CHECKING:  # pragma: no cover
-    FilterT = Callable[..., Any]
-    NumberT = Union[float, int]
+    FilterT = Callable[..., Any]  # pylint: disable=invalid-name
+    NumberT = Union[float, int]  # pylint: disable=invalid-name
 
 
 def with_context(_filter: FilterT) -> FilterT:

--- a/liquid/loaders.py
+++ b/liquid/loaders.py
@@ -111,7 +111,7 @@ class BaseLoader(ABC):
         self, env: Environment, template_name: str, **kwargs: object
     ) -> TemplateSource:
         """An async version of :meth:`get_source_with_args`."""
-        return await self.get_source_async(env, template_name)
+        return self.get_source_with_args(env, template_name, **kwargs)
 
     # pylint: disable=unused-argument
     def get_source_with_context(


### PR DESCRIPTION
This pull request adds `Environment.get_template_with_args()`, `BaseLoader.load_with_args()` and `BaseLoader.get_source_with_args()` methods, plus their async equivalents. These methods allow passing of arbitrary keyword arguments to a template loader.

A future major release of Python Liquid will probably combine the various `Environment.load*` methods into one. For now, we add additional methods to maintain compatibility for those that are subclassing `Environment` and overriding `load_template()`.

The initial use case for such methods is one where the template loader is responsible for caching in a multi-user environment, and the cache key requires some kind of namespace or user ID. Previously, `Environment.from_string()` would be needed to bootstrap a context-aware loader, but that would bypass any loader-implemented caching.

An example project showing how one might configure Python Liquid to use external caching and scalable object storage in a multi-user environment is a work in progress. 