### PR TITLE
feat: async filter interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 **Features**
 
 - Added context-aware template loader bootstrapping methods. See [#109](https://github.com/jg-rp/liquid/pull/109).
+- Added support for async class-based filters. See [#115](https://github.com/jg-rp/liquid/pull/115).
 
 ## Version 1.8.1
 


### PR DESCRIPTION
This pull requests adds support for async filters via an optional `filter_async` method on class-based filters.

When rendered in an async context, the `filter_async` method of the following filter will be awaited, instead of calling `__call__`.

```python
class SomeFilter:
    """A mock class-based filter implementing the async filter interface."""

    def __call__(self, val: object) -> str:
        return "Hello, " + str(val)

    async def filter_async(self, val: object) -> str:
        return "Goodbye, " + str(val)
```