### PR TITLE
fix: map is a sequence filter

### DIFF
--- a/liquid/builtin/filters/array.py
+++ b/liquid/builtin/filters/array.py
@@ -125,7 +125,7 @@ def concat(sequence: ArrayT, second_array: ArrayT) -> ArrayT:
     return list(chain(sequence, second_array))
 
 
-@liquid_filter
+@sequence_filter
 def map_(sequence: ArrayT, key: object) -> List[object]:
     """Create an array of values from a map."""
     try:

--- a/liquid/golden/map_filter.py
+++ b/liquid/golden/map_filter.py
@@ -35,4 +35,16 @@ cases = [
         expect="#",
         globals={"a": [{"title": "foo"}, {"title": "bar"}]},
     ),
+    Case(
+        description="nested arrays get flattened",
+        template=r"{{ a | map: 'title' | join: '#' }}",
+        expect="foo#bar#baz",
+        globals={"a": [{"title": "foo"}, [{"title": "bar"}, {"title": "baz"}]]},
+    ),
+    Case(
+        description="input is a hash",
+        template=r"{{ a | map: 'title' | join: '#' }}",
+        expect="foo",
+        globals={"a": {"title": "foo", "some": "thing"}},
+    ),
 ]


### PR DESCRIPTION
This pull request fixes #119 by decorating our `map` filter implementation with `sequence_filter` rather than `liquid_filter`.