### PR TITLE
Handle unsupported date filter format strings.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Python Liquid Change Log
 
+## Version 1.10.1
+
+**Fixes**
+
+- Fixed unexpected errors from the `date` filter when it's given an invalid format string. Previously we were raising a `liquid.exceptions.Error` in response to a `ValueError` from [strftime](https://docs.python.org/3/library/datetime.html#datetime.date.strftime). We now raise a `FilterArgumentError` with its `__cause__` set to the `ValueError`.
+- Fixed handling of `"%s"` date filter format strings. We now fall back to a string representation of `datetime.timestamp()` for platforms that don't support `%s`. Note that this is for `"%s"` exactly. We don't handle the more general case of `%s` appearing in a longer format string.
+
 ## Version 1.10.0
 
 **Features**

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -42,7 +42,7 @@ from .static_analysis import ContextualTemplateAnalysis
 
 from . import future
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 
 __all__ = (
     "AwareBoundTemplate",

--- a/liquid/golden/date_filter.py
+++ b/liquid/golden/date_filter.py
@@ -55,4 +55,9 @@ cases = [
         template=r"{{ '-1152098955' | date: '%m/%d/%Y' }}",
         expect="-1152098955",
     ),
+    Case(
+        description="seconds since epoch format directive",
+        template=r"{{ 'March 14, 2016' | date: '%s' }}",
+        expect="1457913600",
+    ),
 ]


### PR DESCRIPTION
Python Liquid's `date` filter has some [known compatibility issues](https://jg-rp.github.io/liquid/known_issues#the-date-filter) when compared to Shopify/Liquid. One such incompatibility is caused by the difference between Python's officially supported strftime directives and Ruby's. To make matters worse, some platforms will accept unsupported directives, while others will raise a `ValueError`. For example, `"%s"` will usually work when running Python on Linux, but not on Windows.

This PR changes the `date` filter to handle `"%s"` as a special case, and wraps the `ValueError` in a `FilterArgumentError`.

See #129