### PR TITLE
Fix `split` filter compatibility issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Python Liquid Change Log
 
+## Version 1.11.0 (unreleased)
+
+**Fixes**
+
+- Added an additional implementation of the `split` filter, which resolves some compatibility issues between Python Liquid's and the reference implementation. Previously, when given an empty string to split or when the string and the delimiter were equal, we used Python's `str.split()` behavior of producing one or two element lists containing empty strings. We now match Shopify/Liquid in returning an empty list for such cases. The new `split` filter will be enabled by default when using [`liquid.future.Environment`](https://jg-rp.github.io/liquid/api/future-environment), and can optionally be registered with `liquid.Environment` for those that don't mind the behavioral change. See [#135](https://github.com/jg-rp/liquid/pull/135).
+
 ## Version 1.10.1
 
 **Fixes**

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -42,7 +42,7 @@ from .static_analysis import ContextualTemplateAnalysis
 
 from . import future
 
-__version__ = "1.10.1"
+__version__ = "1.11.0"
 
 __all__ = (
     "AwareBoundTemplate",

--- a/liquid/future/environment.py
+++ b/liquid/future/environment.py
@@ -5,6 +5,7 @@ template rendering behavior.
 """
 from ..environment import Environment as DefaultEnvironment
 from ..template import FutureBoundTemplate
+from .filters import split
 
 
 class Environment(DefaultEnvironment):
@@ -19,3 +20,8 @@ class Environment(DefaultEnvironment):
     """
 
     template_class = FutureBoundTemplate
+
+    def setup_tags_and_filters(self) -> None:
+        """Add future tags and filters to this environment."""
+        super().setup_tags_and_filters()
+        self.add_filter("split", split)

--- a/liquid/future/filters/__init__.py
+++ b/liquid/future/filters/__init__.py
@@ -1,0 +1,3 @@
+from ._split import split  # noqa: D104
+
+__all__ = ("split",)

--- a/liquid/future/filters/_split.py
+++ b/liquid/future/filters/_split.py
@@ -1,0 +1,21 @@
+"""An implementation of the `split` filter."""
+
+from typing import List
+
+from liquid import soft_str
+from liquid.filter import string_filter
+
+
+@string_filter
+def split(val: str, sep: str) -> List[str]:
+    """Split string _val_ on delimiter _sep_."""
+    if not sep:
+        return list(val)
+
+    if not val:
+        return []
+
+    if val == sep:
+        return []
+
+    return val.split(soft_str(sep))

--- a/liquid/future/filters/_split.py
+++ b/liquid/future/filters/_split.py
@@ -8,7 +8,12 @@ from liquid.filter import string_filter
 
 @string_filter
 def split(val: str, sep: str) -> List[str]:
-    """Split string _val_ on delimiter _sep_."""
+    """Split string _val_ on delimiter _sep_.
+
+    If _sep_ is empty or _undefined_, _val_ is split into a list of single
+    characters. If _val_ is empty or equal to _sep_, and empty list is
+    returned.
+    """
     if not sep:
         return list(val)
 

--- a/liquid/future/filters/_split.py
+++ b/liquid/future/filters/_split.py
@@ -11,8 +11,7 @@ def split(val: str, sep: str) -> List[str]:
     """Split string _val_ on delimiter _sep_.
 
     If _sep_ is empty or _undefined_, _val_ is split into a list of single
-    characters. If _val_ is empty or equal to _sep_, and empty list is
-    returned.
+    characters. If _val_ is empty or equal to _sep_, an empty list is returned.
     """
     if not sep:
         return list(val)

--- a/liquid/future/filters/_split.py
+++ b/liquid/future/filters/_split.py
@@ -15,7 +15,8 @@ def split(val: str, sep: str) -> List[str]:
     if not val:
         return []
 
+    sep = soft_str(sep)
     if val == sep:
         return []
 
-    return val.split(soft_str(sep))
+    return val.split(sep)

--- a/liquid/future/filters/_split.py
+++ b/liquid/future/filters/_split.py
@@ -12,11 +12,8 @@ def split(val: str, sep: str) -> List[str]:
     if not sep:
         return list(val)
 
-    if not val:
-        return []
-
     sep = soft_str(sep)
-    if val == sep:
+    if not val or val == sep:
         return []
 
     return val.split(sep)

--- a/liquid/golden/split_filter.py
+++ b/liquid/golden/split_filter.py
@@ -85,4 +85,13 @@ cases = [
         expect="",
         future=True,
     ),
+    Case(
+        description="left matches string repr of argument",
+        template=(
+            r'{% assign a = "1" | split: 1 %}'
+            r"{% for i in a %}{{ forloop.index0 }}{{ i }}{% endfor %}"
+        ),
+        expect="",
+        future=True,
+    ),
 ]

--- a/liquid/golden/split_filter.py
+++ b/liquid/golden/split_filter.py
@@ -47,6 +47,7 @@ cases = [
             r"{% for i in a %}#{{ forloop.index0 }}{{ i }}{% endfor %}"
         ),
         expect="#0a#1b#2c",
+        future=True,
     ),
     Case(
         description="argument does not appear in string",
@@ -55,6 +56,7 @@ cases = [
             r"{% for i in a %}#{{ forloop.index0 }}{{ i }}{% endfor %}"
         ),
         expect="#0abc",
+        future=True,
     ),
     Case(
         description="empty string and empty argument",
@@ -63,6 +65,7 @@ cases = [
             r"{% for i in a %}{{ forloop.index0 }}{{ i }}{% endfor %}"
         ),
         expect="",
+        future=True,
     ),
     Case(
         description="empty string and single char argument",
@@ -71,6 +74,7 @@ cases = [
             r"{% for i in a %}{{ forloop.index0 }}{{ i }}{% endfor %}"
         ),
         expect="",
+        future=True,
     ),
     Case(
         description="left matches argument",
@@ -79,5 +83,6 @@ cases = [
             r"{% for i in a %}{{ forloop.index0 }}{{ i }}{% endfor %}"
         ),
         expect="",
+        future=True,
     ),
 ]

--- a/liquid/golden/split_filter.py
+++ b/liquid/golden/split_filter.py
@@ -40,4 +40,44 @@ cases = [
         template=r'{{ "Hello there" | split: nosuchthing | join: "#" }}',
         expect="H#e#l#l#o# #t#h#e#r#e",
     ),
+    Case(
+        description="empty string argument",
+        template=(
+            r'{% assign a = "abc" | split: "" %}'
+            r"{% for i in a %}#{{ forloop.index0 }}{{ i }}{% endfor %}"
+        ),
+        expect="#0a#1b#2c",
+    ),
+    Case(
+        description="argument does not appear in string",
+        template=(
+            r'{% assign a = "abc" | split: "," %}'
+            r"{% for i in a %}#{{ forloop.index0 }}{{ i }}{% endfor %}"
+        ),
+        expect="#0abc",
+    ),
+    Case(
+        description="empty string and empty argument",
+        template=(
+            r'{% assign a = "" | split: "" %}'
+            r"{% for i in a %}{{ forloop.index0 }}{{ i }}{% endfor %}"
+        ),
+        expect="",
+    ),
+    Case(
+        description="empty string and single char argument",
+        template=(
+            r'{% assign a = "" | split: "," %}'
+            r"{% for i in a %}{{ forloop.index0 }}{{ i }}{% endfor %}"
+        ),
+        expect="",
+    ),
+    Case(
+        description="left matches argument",
+        template=(
+            r'{% assign a = "," | split: "," %}'
+            r"{% for i in a %}{{ forloop.index0 }}{{ i }}{% endfor %}"
+        ),
+        expect="",
+    ),
 ]


### PR DESCRIPTION
This PR adds a new implementation of the `split` filter which resolves some compatibility issues when compared to Shopify/Liquid (the reference implementation).

The new `split` filter will be enabled by default when using [`liquid.future.Environment`](https://jg-rp.github.io/liquid/api/future-environment), and can optionally be registered with `liquid.Environment` for those that don't mind the behavioural change. Like this:

```python
from liquid import Environment
from liquid.future.filters import split

env = Environment()
env.add_filter("split", split)

template = env.from_string('{% assign items = "" | split: "," %}{{items | size}}')
print(template.render())
```

Closes #134.