### PR TITLE
Template loader factory functions.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.7"
+          - os: windows-latest
+            python-version: "3.7"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,12 @@
 
 **Fixes**
 
-- Fixed a bug with the LRU cache. We now raise a `ValueError` at construction time if a caching template loader is given a cache size less than 1. Previously, in such cases, an `IndexError` would have been raised when attempting to write to the cache.
+- Fixed a bug with the LRU cache. We now raise a `ValueError` at construction time if a caching template loader is given a cache size less than 1. Previously, in such cases, an `IndexError` would have been raised when attempting to write to the cache. See [#148](https://github.com/jg-rp/liquid/issues/148).
 
 **Features**
 
-- Added `make_choice_loader()`, a factory function that returns a `ChoiceLoader` or `CachingChoiceLoader` depending on its arguments.
-- Added `make_file_system_loader()`, a factory function that returns a `FileSystemLoader`, `FileExtensionLoader` or `CachingFileSystemLoader` depending on its arguments.
+- Added `make_choice_loader()`, a factory function that returns a `ChoiceLoader` or `CachingChoiceLoader` depending on its arguments. ([docs](https://jg-rp.github.io/liquid/api/make-choice-loader))
+- Added `make_file_system_loader()`, a factory function that returns a `FileSystemLoader`, `FileExtensionLoader` or `CachingFileSystemLoader` depending on its arguments. ([docs](https://jg-rp.github.io/liquid/api/make-file-system-loader))
 
 ## Version 1.11.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Python Liquid Change Log
 
+## Version 1.12.0 (unreleased)
+
+**Fixes**
+
+- Fixed a bug with the LRU cache. We now raise a `ValueError` at construction time if a caching template loader is given a cache size less than 1. Previously, in such cases, an `IndexError` would have been raised when attempting to write to the cache.
+
+**Features**
+
+- Added `make_choice_loader()`, a factory function that returns a `ChoiceLoader` or `CachingChoiceLoader` depending on its arguments.
+- Added `make_file_system_loader()`, a factory function that returns a `FileSystemLoader`, `FileExtensionLoader` or `CachingFileSystemLoader` depending on its arguments.
+
 ## Version 1.11.0
 
 **Fixes**

--- a/docs/loaders.md
+++ b/docs/loaders.md
@@ -27,3 +27,8 @@
 ::: liquid.loaders.TemplateSource
     handler: python
 
+::: liquid.loaders.make_choice_loader
+    handler: python
+
+::: liquid.loaders.make_file_system_loader
+    handler: python

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -44,7 +44,7 @@ from .static_analysis import ContextualTemplateAnalysis
 
 from . import future
 
-__version__ = "1.11.0"
+__version__ = "1.12.0"
 
 __all__ = (
     "AwareBoundTemplate",

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -19,6 +19,8 @@ from .loaders import DictLoader
 from .loaders import FileExtensionLoader
 from .loaders import FileSystemLoader
 from .loaders import PackageLoader
+from .loaders import make_choice_loader
+from .loaders import make_file_system_loader
 
 from .context import Context
 from .context import DebugUndefined
@@ -67,6 +69,8 @@ __all__ = (
     "FutureBoundTemplate",
     "FutureContext",
     "is_undefined",
+    "make_choice_loader",
+    "make_file_system_loader",
     "Markup",
     "Mode",
     "PackageLoader",

--- a/liquid/builtin/loaders/__init__.py
+++ b/liquid/builtin/loaders/__init__.py
@@ -27,6 +27,8 @@ __all__ = (
     "DictLoader",
     "FileExtensionLoader",
     "FileSystemLoader",
+    "make_choice_loader",
+    "make_file_system_loader",
     "PackageLoader",
     "TemplateNamespace",
     "TemplateSource",

--- a/liquid/builtin/loaders/__init__.py
+++ b/liquid/builtin/loaders/__init__.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+from typing import Iterable
+from typing import List
+from typing import Union
+
 from .base_loader import BaseLoader
 from .base_loader import DictLoader
 from .base_loader import TemplateNamespace
@@ -27,3 +32,100 @@ __all__ = (
     "TemplateSource",
     "UpToDate",
 )
+
+
+def make_file_system_loader(
+    search_path: Union[str, Path, Iterable[Union[str, Path]]],
+    *,
+    encoding: str = "utf-8",
+    ext: str = ".liquid",
+    auto_reload: bool = True,
+    namespace_key: str = "",
+    cache_size: int = 300,
+) -> BaseLoader:
+    """A _file system_ template loader factory.
+
+    Returns one of `CachingFileSystemLoader`, `FileExtensionLoader` or
+    `FileSystemLoader` depending in the given arguments.
+
+    A `CachingFileSystemLoader` is returned if _cache_size_ is greater than 0.
+    Otherwise a `FileExtensionLoader` is returned if _ext_ is not empty.
+    Otherwise a `FileSystemLoader` is returned.
+
+    _auto_reload_ and _namespace_key_ are ignored if _cache_key_ is less than 1.
+
+    Args:
+        search_path: One or more paths to search.
+        encoding: Open template files with the given encoding.
+        ext: A default file extension. Should include a leading period.
+        auto_reload: If `True`, automatically reload a cached template if it has been
+            updated.
+        namespace_key: The name of a global render context variable or loader keyword
+            argument that resolves to the current loader "namespace" or "scope".
+
+            If you're developing a multi-user application, a good namespace might be
+            `uid`, where `uid` is a unique identifier for a user and templates are
+            arranged in folders named for each `uid` inside the search path.
+        cache_size: The maximum number of templates to hold in the cache before removing
+            the least recently used template.
+
+    _New in version 1.12.0_
+    """
+    if cache_size > 0:
+        return CachingFileSystemLoader(
+            search_path=search_path,
+            encoding=encoding,
+            ext=ext,
+            auto_reload=auto_reload,
+            namespace_key=namespace_key,
+            cache_size=cache_size,
+        )
+
+    if ext:
+        return FileExtensionLoader(
+            search_path=search_path,
+            encoding=encoding,
+            ext=ext,
+        )
+
+    return FileSystemLoader(search_path=search_path, encoding=encoding)
+
+
+def make_choice_loader(
+    loaders: List[BaseLoader],
+    *,
+    auto_reload: bool = True,
+    namespace_key: str = "",
+    cache_size: int = 300,
+) -> BaseLoader:
+    """A _choice loader_ factory.
+
+    Returns one of `CachingChoiceLoader` or `ChoiceLoader` depending on the
+    given arguments.
+
+    A `CachingChoiceLoader` is returned if _cache_size_ > 0, otherwise a
+    `ChoiceLoader` is returned.
+
+    _auto_reload_ and _namespace_key_ are ignored if _cache_key_ is less than 1.
+
+    Args:
+        loaders: A list of loaders implementing `liquid.loaders.BaseLoader`.
+        auto_reload: If `True`, automatically reload a cached template if it
+            has been updated.
+        namespace_key: The name of a global render context variable or loader
+            keyword argument that resolves to the current loader "namespace" or
+            "scope".
+        cache_size: The maximum number of templates to hold in the cache before
+            removing the least recently used template.
+
+    _New in version 1.12.0_
+    """
+    if cache_size > 0:
+        return CachingChoiceLoader(
+            loaders=loaders,
+            auto_reload=auto_reload,
+            namespace_key=namespace_key,
+            cache_size=cache_size,
+        )
+
+    return ChoiceLoader(loaders=loaders)

--- a/liquid/builtin/loaders/__init__.py
+++ b/liquid/builtin/loaders/__init__.py
@@ -52,7 +52,7 @@ def make_file_system_loader(
 
     A `CachingFileSystemLoader` is returned if _cache_size_ is greater than 0.
     Otherwise a `FileExtensionLoader` is returned if _ext_ is not empty.
-    Otherwise a `FileSystemLoader` is returned.
+    If _ext_ is empty, a `FileSystemLoader` is returned.
 
     _auto_reload_ and _namespace_key_ are ignored if _cache_key_ is less than 1.
 

--- a/liquid/exceptions.py
+++ b/liquid/exceptions.py
@@ -235,3 +235,7 @@ class Markup(str):
         raise Error(
             "autoescape requires Markupsafe to be installed"
         )  # pragma: no cover
+
+
+class CacheCapacityValueError(ValueError):
+    """An exception raised when the LRU cache is given a zero or negative capacity."""

--- a/liquid/loaders.py
+++ b/liquid/loaders.py
@@ -10,6 +10,8 @@ from .builtin.loaders import PackageLoader
 from .builtin.loaders import TemplateNamespace
 from .builtin.loaders import TemplateSource
 from .builtin.loaders import UpToDate
+from .builtin.loaders import make_choice_loader
+from .builtin.loaders import make_file_system_loader
 
 __all__ = (
     "BaseLoader",
@@ -19,6 +21,8 @@ __all__ = (
     "DictLoader",
     "FileExtensionLoader",
     "FileSystemLoader",
+    "make_choice_loader",
+    "make_file_system_loader",
     "PackageLoader",
     "TemplateNamespace",
     "TemplateSource",

--- a/liquid/utils/cache.py
+++ b/liquid/utils/cache.py
@@ -36,6 +36,8 @@ from collections import abc
 from collections import deque
 from threading import Lock
 
+from liquid.exceptions import CacheCapacityValueError
+
 
 class LRUCache(abc.MutableMapping):
     """A simple LRU Cache implementation."""
@@ -45,6 +47,9 @@ class LRUCache(abc.MutableMapping):
     # won't do any harm.
 
     def __init__(self, capacity: int):
+        if capacity < 1:
+            raise CacheCapacityValueError("cache size must be greater than 1")
+
         self.capacity = capacity
         self._mapping = {}
         self._queue = deque()

--- a/tests/test_caching_loader.py
+++ b/tests/test_caching_loader.py
@@ -239,6 +239,16 @@ class CachingFileSystemLoaderTestCase(unittest.TestCase):
         template = env.get_template_with_context(context, "dropify/index.liquid")
         self.assertNotEqual(template.render(), "namespaced template")
 
+    def test_zero_capacity_cache(self):
+        """Test that we get an exception when cache size is zero."""
+        with self.assertRaises(ValueError):
+            CachingFileSystemLoader("tests/fixtures/", cache_size=0)
+
+    def test_negative_capacity_cache(self):
+        """Test that we get an exception when cache size is negative."""
+        with self.assertRaises(ValueError):
+            CachingFileSystemLoader("tests/fixtures/", cache_size=-1)
+
 
 class CachingChoiceLoaderTestCase(unittest.TestCase):
     """Test loading templates with caching from a list of loaders."""

--- a/tests/test_template_loader_factories.py
+++ b/tests/test_template_loader_factories.py
@@ -1,0 +1,40 @@
+"""Template loader factory test cases."""
+import unittest
+
+from liquid.loaders import CachingChoiceLoader
+from liquid.loaders import CachingFileSystemLoader
+from liquid.loaders import ChoiceLoader
+from liquid.loaders import DictLoader
+from liquid.loaders import FileExtensionLoader
+from liquid.loaders import FileSystemLoader
+from liquid.loaders import make_choice_loader
+from liquid.loaders import make_file_system_loader
+
+
+class TemplateLoaderFactoryTestCase(unittest.TestCase):
+    """Template loader factory test cases."""
+
+    def test_make_file_system_loader(self):
+        """Test that we can make a file system loader."""
+        loader = make_file_system_loader("tests/fixtures/", ext="", cache_size=0)
+        self.assertIsInstance(loader, FileSystemLoader)
+
+    def test_make_file_extension_loader(self):
+        """Test that we can make a file extension loader."""
+        loader = make_file_system_loader("tests/fixtures/", ext=".liquid", cache_size=0)
+        self.assertIsInstance(loader, FileExtensionLoader)
+
+    def test_make_caching_file_system_loader(self):
+        """Test that we can make a caching file system loader."""
+        loader = make_file_system_loader("tests/fixtures/", ext=".liquid", cache_size=1)
+        self.assertIsInstance(loader, CachingFileSystemLoader)
+
+    def test_make_choice_loader(self):
+        """Test that we can make a choice loader."""
+        loader = make_choice_loader([DictLoader({})], cache_size=0)
+        self.assertIsInstance(loader, ChoiceLoader)
+
+    def test_make_caching_choice_loader(self):
+        """Test that we can make a caching choice loader."""
+        loader = make_choice_loader([DictLoader({})], cache_size=1)
+        self.assertIsInstance(loader, CachingChoiceLoader)

--- a/tests/test_template_loader_factories.py
+++ b/tests/test_template_loader_factories.py
@@ -1,14 +1,14 @@
 """Template loader factory test cases."""
 import unittest
 
-from liquid.loaders import CachingChoiceLoader
-from liquid.loaders import CachingFileSystemLoader
-from liquid.loaders import ChoiceLoader
-from liquid.loaders import DictLoader
-from liquid.loaders import FileExtensionLoader
-from liquid.loaders import FileSystemLoader
-from liquid.loaders import make_choice_loader
-from liquid.loaders import make_file_system_loader
+from liquid import CachingChoiceLoader
+from liquid import CachingFileSystemLoader
+from liquid import ChoiceLoader
+from liquid import DictLoader
+from liquid import FileExtensionLoader
+from liquid import FileSystemLoader
+from liquid import make_choice_loader
+from liquid import make_file_system_loader
 
 
 class TemplateLoaderFactoryTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR adds `make_choice_loader()` and `make_file_system_loader()`, factory functions that pick an appropriate template loader based on their arguments. 

We also make `LRUCache` fail early and loud if its capacity is less than 1.

See #148.