### PR TITLE
fix: handle superfluous `else` and `elsif` blocks and expressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Python Liquid Change Log
 
+## Version 1.12.1 (unreleased)
+
+**Fixes**
+
+- Fixed handling of `{% else %}` tags that include text between `else` and the closing tag delimiter (`%}`). Previously we were treating such text as part of the `else` block, we now follow Shopify/Liquid behavior by ignoring it, even in strict mode. See [#150](https://github.com/jg-rp/liquid/issues/150).
+- Fixed handling of superfluous `{% else %}` and `{% elsif %}` blocks. Previously we would raise a `LiquidSyntaxError`, now we ignore them, as Shopify/Liquid does. See [#151](https://github.com/jg-rp/liquid/issues/151).
+
 ## Version 1.12.0
 
 **Fixes**

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -46,7 +46,7 @@ from .static_analysis import ContextualTemplateAnalysis
 
 from . import future
 
-__version__ = "1.12.0"
+__version__ = "1.12.1"
 
 __all__ = (
     "AwareBoundTemplate",

--- a/liquid/golden/if_tag.py
+++ b/liquid/golden/if_tag.py
@@ -267,4 +267,28 @@ cases = [
         globals={},
         expect="true",
     ),
+    Case(
+        description="else tag expressions are ignored",
+        template="{% if false %}1{% else nonsense %}2{% endif %}",
+        globals={},
+        expect="2",
+        error=False,
+        strict=True,
+    ),
+    Case(
+        description="extra else blocks are ignored",
+        template="{% if false %}1{% else %}2{% else %}3{% endif %}",
+        globals={},
+        expect="2",
+        error=False,
+        strict=True,
+    ),
+    Case(
+        description="extra elsif blocks are ignored",
+        template="{% if false %}1{% else %}2{% elsif true %}3{% endif %}",
+        globals={},
+        expect="2",
+        error=False,
+        strict=True,
+    ),
 ]

--- a/liquid/golden/unless_tag.py
+++ b/liquid/golden/unless_tag.py
@@ -71,4 +71,28 @@ cases = [
         globals={"x": ["a", "b", "c"]},
         expect="false",
     ),
+    Case(
+        description="else tag expressions are ignored",
+        template="{% unless true %}1{% else nonsense %}2{% endunless %}",
+        globals={},
+        expect="2",
+        error=False,
+        strict=True,
+    ),
+    Case(
+        description="extra else blocks are ignored",
+        template="{% unless true %}1{% else %}2{% else %}3{% endunless %}",
+        globals={},
+        expect="2",
+        error=False,
+        strict=True,
+    ),
+    Case(
+        description="extra elsif blocks are ignored",
+        template="{% unless true %}1{% else %}2{% elsif true %}3{% endunless %}",
+        globals={},
+        expect="2",
+        error=False,
+        strict=True,
+    ),
 ]


### PR DESCRIPTION
This PR updates the built-in `IfTag` and `UnlessTag` parsers to handle superfluous expressions inside `{% else %}` blocks, and superfluous `{% else %}` and `{% elsif %}` blocks after the first `else`. We now silently ignore these extra expressions and blocks, as does Shopify/Liquid.

It would be possible to apply these fixes to the [future `Environment`](https://jg-rp.github.io/liquid/api/future-environment) only, or raise a syntax errors in such cases when in strict mode only, but, to minimise confusion, we're just following Shopify/Liquid by default.

Closes #150
Closes #151