### PR TITLE
Move lax `else` tag parsing to the "future" environment.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,8 @@
 
 **Fixes**
 
-- Fixed handling of `{% else %}` tags that include text between `else` and the closing tag delimiter (`%}`). Previously we were treating such text as part of the `else` block, we now follow Shopify/Liquid behavior by ignoring it, even in strict mode. See [#150](https://github.com/jg-rp/liquid/issues/150).
-- Fixed handling of superfluous `{% else %}` and `{% elsif %}` blocks. Previously we would raise a `LiquidSyntaxError`, now we ignore them, as Shopify/Liquid does. See [#151](https://github.com/jg-rp/liquid/issues/151).
+- Fixed handling of `{% else %}` tags that include text between `else` and the closing tag delimiter (`%}`). Previously we were treating such text as part of the `{% else %}` block. Now the default behavior is to raise a `LiquidSyntaxError`. When using [`liquid.future.Environment`](https://jg-rp.github.io/liquid/api/future-environment), we follow Shopify/Liquid behavior of silently ignoring `{% else %}` tag expressions, even in strict mode. See [#150](https://github.com/jg-rp/liquid/issues/150).
+- [`liquid.future.Environment`](https://jg-rp.github.io/liquid/api/future-environment) now silently ignores superfluous `{% else %}` and `{% elsif %}` blocks. The default environment continues to raise a `LiquidSyntaxError` if `{% else %}` or `{% elsif %}` appear after the first `{% else %}` tag. See [#151](https://github.com/jg-rp/liquid/issues/151).
 
 ## Version 1.12.0
 

--- a/liquid/future/environment.py
+++ b/liquid/future/environment.py
@@ -1,4 +1,4 @@
-"""An environment that is configured for maximum compatibility with Ruby Liquid.
+"""An environment that's configured for maximum compatibility with Shopify/Liquid.
 
 This environment will be updated without concern for backwards incompatible changes to
 template rendering behavior.
@@ -6,13 +6,15 @@ template rendering behavior.
 from ..environment import Environment as DefaultEnvironment
 from ..template import FutureBoundTemplate
 from .filters import split
+from .tags import LaxIfTag
+from .tags import LaxUnlessTag
 
 
 class Environment(DefaultEnvironment):
-    """An environment that is configured for maximum compatibility with Ruby Liquid.
+    """An environment that's configured for maximum compatibility with Shopify/Liquid.
 
     This environment addresses some compatibility issues between Python Liquid's default
-    `Environment` and Ruby Liquid. These issues are considered to be an unacceptable
+    `Environment` and Shopify/Liquid. These issues are considered to be an unacceptable
     breaking changes for users that rely on existing behavior of the default
     environment.
 
@@ -25,3 +27,5 @@ class Environment(DefaultEnvironment):
         """Add future tags and filters to this environment."""
         super().setup_tags_and_filters()
         self.add_filter("split", split)
+        self.add_tag(LaxIfTag)
+        self.add_tag(LaxUnlessTag)

--- a/liquid/future/tags/__init__.py
+++ b/liquid/future/tags/__init__.py
@@ -1,0 +1,7 @@
+from ._if_tag import LaxIfTag  # noqa: D104
+from ._unless_tag import LaxUnlessTag
+
+__all__ = (
+    "LaxIfTag",
+    "LaxUnlessTag",
+)

--- a/liquid/future/tags/_if_tag.py
+++ b/liquid/future/tags/_if_tag.py
@@ -1,0 +1,8 @@
+from liquid.builtin.tags.if_tag import IfTag
+from liquid.mode import Mode
+
+
+class LaxIfTag(IfTag):
+    """An `if` tag that is lax in its handling of extra expressions and blocks."""
+
+    mode = Mode.LAX

--- a/liquid/future/tags/_unless_tag.py
+++ b/liquid/future/tags/_unless_tag.py
@@ -1,0 +1,8 @@
+from liquid.builtin.tags.unless_tag import UnlessTag
+from liquid.mode import Mode
+
+
+class LaxUnlessTag(UnlessTag):
+    """An `unless` tag that is lax in its handling of extra expressions and blocks."""
+
+    mode = Mode.LAX

--- a/liquid/golden/if_tag.py
+++ b/liquid/golden/if_tag.py
@@ -274,6 +274,7 @@ cases = [
         expect="2",
         error=False,
         strict=True,
+        future=True,
     ),
     Case(
         description="extra else blocks are ignored",
@@ -282,6 +283,7 @@ cases = [
         expect="2",
         error=False,
         strict=True,
+        future=True,
     ),
     Case(
         description="extra elsif blocks are ignored",
@@ -290,6 +292,7 @@ cases = [
         expect="2",
         error=False,
         strict=True,
+        future=True,
     ),
     Case(
         description="empty array equals special empty",

--- a/liquid/golden/unless_tag.py
+++ b/liquid/golden/unless_tag.py
@@ -78,6 +78,7 @@ cases = [
         expect="2",
         error=False,
         strict=True,
+        future=True,
     ),
     Case(
         description="extra else blocks are ignored",
@@ -86,6 +87,7 @@ cases = [
         expect="2",
         error=False,
         strict=True,
+        future=True,
     ),
     Case(
         description="extra elsif blocks are ignored",
@@ -94,5 +96,6 @@ cases = [
         expect="2",
         error=False,
         strict=True,
+        future=True,
     ),
 ]

--- a/liquid/mode.py
+++ b/liquid/mode.py
@@ -5,7 +5,7 @@ from enum import auto
 
 
 class Mode(IntEnum):
-    """Template correctness tolerance."""
+    """Template error tolerance mode."""
 
     LAX = auto()
     WARN = auto()

--- a/tests/test_malformed.py
+++ b/tests/test_malformed.py
@@ -357,6 +357,32 @@ class MalformedTemplateTestCase(TestCase):
                     "expected a filter or end of expression, found 'offset', on line 1"
                 ),
             ),
+            Case(
+                description="unexpected expression in 'else' tag",
+                template=r"{% if true %}a{% else foo %}b{% endif %}",
+                expect_exception=LiquidSyntaxError,
+                expect_msg=(
+                    "found an 'else' tag expression, did you mean 'elsif'?, on line 1"
+                ),
+            ),
+            Case(
+                description="extra 'else' block",
+                template=r"{% if true %}a{% else %}b{% else %}c{% endif %}",
+                expect_exception=LiquidSyntaxError,
+                expect_msg=(
+                    "expected tag with value 'endif', found tag with value 'else', "
+                    "on line 1"
+                ),
+            ),
+            Case(
+                description="extra 'elsif' block",
+                template=r"{% if true %}a{% else %}b{% elsif %}c{% endif %}",
+                expect_exception=LiquidSyntaxError,
+                expect_msg=(
+                    "expected tag with value 'endif', found tag with value 'elsif', "
+                    "on line 1"
+                ),
+            ),
         ]
 
         self._test(test_cases, mode=Mode.STRICT)

--- a/tests/test_render_extra.py
+++ b/tests/test_render_extra.py
@@ -70,7 +70,7 @@ class RenderIfNotTagTestCase(BaseRenderTestCase):
 
     def test_render_standard_if_tag(self) -> None:
         """Test that the `if (not)` tag renders standard `if` tags."""
-        self._test(golden.if_tag.cases)
+        self._test([case for case in golden.if_tag.cases if not case.future])
 
     def test_render_non_standard_if_tag(self) -> None:
         """Test that we can render `if` tags with logical `not` and grouping


### PR DESCRIPTION
This PR enables lax parsing of `else` tags and extra `else`/`elsif` blocks (introduced with #152) in the [future `Environment`](https://jg-rp.github.io/liquid/api/future-environment). The default `Environment` now maintains its previous strictness and handles the bug described in #150.