### PR TITLE
Add Shopify compatible case tag.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Python Liquid Change Log
 
+## Version 1.12.2
+
+**Fixes**
+
+- Fixed `{% case %}` / `{% when %}` behavior. When using [`liquid.future.Environment`](https://jg-rp.github.io/liquid/api/future-environment), we now render any number of `{% else %}` blocks and allow `{% when %}` tags to appear after `{% else %}` tags. The default `Environment` continues to raise a `LiquidSyntaxError` in such cases.
+
 ## Version 1.12.1
 
 **Fixes**

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -46,7 +46,7 @@ from .static_analysis import ContextualTemplateAnalysis
 
 from . import future
 
-__version__ = "1.12.1"
+__version__ = "1.12.2"
 
 __all__ = (
     "AwareBoundTemplate",

--- a/liquid/future/environment.py
+++ b/liquid/future/environment.py
@@ -6,6 +6,7 @@ template rendering behavior.
 from ..environment import Environment as DefaultEnvironment
 from ..template import FutureBoundTemplate
 from .filters import split
+from .tags import LaxCaseTag
 from .tags import LaxIfTag
 from .tags import LaxUnlessTag
 
@@ -27,5 +28,6 @@ class Environment(DefaultEnvironment):
         """Add future tags and filters to this environment."""
         super().setup_tags_and_filters()
         self.add_filter("split", split)
+        self.add_tag(LaxCaseTag)
         self.add_tag(LaxIfTag)
         self.add_tag(LaxUnlessTag)

--- a/liquid/future/tags/__init__.py
+++ b/liquid/future/tags/__init__.py
@@ -1,7 +1,9 @@
-from ._if_tag import LaxIfTag  # noqa: D104
+from ._case_tag import LaxCaseTag  # noqa: D104
+from ._if_tag import LaxIfTag
 from ._unless_tag import LaxUnlessTag
 
 __all__ = (
+    "LaxCaseTag",
     "LaxIfTag",
     "LaxUnlessTag",
 )

--- a/liquid/future/tags/_case_tag.py
+++ b/liquid/future/tags/_case_tag.py
@@ -144,7 +144,7 @@ class LaxCaseTag(CaseTag):
                 blocks.append(self.parser.parse_block(stream, ENDWHENBLOCK))
             elif stream.current.istag(TAG_WHEN):
                 when_tok = stream.next_token()
-                expect(stream, TOKEN_EXPRESSION)  # XXX: empty when expressions?
+                expect(stream, TOKEN_EXPRESSION)
 
                 when_exprs = [
                     BooleanExpression(InfixExpression(case, "==", expr))

--- a/liquid/future/tags/_case_tag.py
+++ b/liquid/future/tags/_case_tag.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from typing import List
+from typing import Optional
+from typing import TextIO
+from typing import Union
+
+from liquid import ast
+from liquid.builtin.tags.case_tag import ENDWHENBLOCK
+from liquid.builtin.tags.case_tag import TAG_CASE
+from liquid.builtin.tags.case_tag import TAG_ELSE
+from liquid.builtin.tags.case_tag import TAG_ENDCASE
+from liquid.builtin.tags.case_tag import TAG_WHEN
+from liquid.builtin.tags.case_tag import CaseTag
+from liquid.exceptions import LiquidSyntaxError
+from liquid.expression import BooleanExpression
+from liquid.expression import InfixExpression
+from liquid.parse import expect
+from liquid.token import TOKEN_EXPRESSION
+from liquid.token import TOKEN_TAG
+from liquid.token import Token
+
+if TYPE_CHECKING:
+    from liquid.context import Context
+    from liquid.stream import TokenStream
+
+
+@dataclass
+class _Block:
+    tag: str
+    node: Union[ast.BlockNode, ast.ConditionalBlockNode]
+
+
+class LaxCaseNode(ast.Node):
+    """Parse tree node for the lax "case" tag."""
+
+    __slots__ = ("tok", "blocks", "forced_output")
+
+    def __init__(
+        self,
+        tok: Token,
+        blocks: List[_Block],
+    ):
+        self.tok = tok
+        self.blocks = blocks
+
+        self.forced_output = self.force_output or any(
+            b.node.forced_output for b in self.blocks
+        )
+
+    def __str__(self) -> str:
+        buf = (
+            ["if (False) { }"]
+            if not self.blocks or self.blocks[0].tag == TAG_ELSE
+            else [f"if {self.blocks[0].node}"]
+        )
+
+        for block in self.blocks:
+            if block.tag == TAG_ELSE:
+                buf.append(f"else {block.node}")
+            elif block.tag == TAG_WHEN:
+                buf.append(f"elsif {block.node}")
+
+        return " ".join(buf)
+
+    def render_to_output(self, context: Context, buffer: TextIO) -> Optional[bool]:
+        buf = context.get_buffer(buffer)
+        rendered: Optional[bool] = False
+
+        for block in self.blocks:
+            if block.tag == TAG_WHEN:
+                rendered = block.node.render(context, buf) or rendered
+            elif block.tag == TAG_ELSE and not rendered:
+                block.node.render(context, buf)
+
+        val = buf.getvalue()
+        if self.forced_output or not val.isspace():
+            buffer.write(val)
+
+        return rendered
+
+    async def render_to_output_async(
+        self, context: Context, buffer: TextIO
+    ) -> Optional[bool]:
+        buf = context.get_buffer(buffer)
+        rendered: Optional[bool] = False
+
+        for block in self.blocks:
+            if block.tag == TAG_WHEN:
+                rendered = await block.node.render_async(context, buf) or rendered
+            elif block.tag == TAG_ELSE and not rendered:
+                await block.node.render_async(context, buf)
+
+        val = buf.getvalue()
+        if self.forced_output or not val.isspace():
+            buffer.write(val)
+
+        return rendered
+
+    def children(self) -> List[ast.ChildNode]:
+        _children = []
+
+        for block in self.blocks:
+            if isinstance(block.node, ast.BlockNode):
+                _children.append(
+                    ast.ChildNode(
+                        linenum=block.node.tok.linenum,
+                        node=block.node,
+                        expression=None,
+                    )
+                )
+            elif isinstance(block.node, ast.ConditionalBlockNode):
+                _children.append(
+                    ast.ChildNode(
+                        linenum=block.node.tok.linenum,
+                        node=block.node,
+                        expression=block.node.condition,
+                    )
+                )
+
+        return _children
+
+
+class LaxCaseTag(CaseTag):
+    """A `case` tag that is lax in its handling of extra `else` and `when` blocks."""
+
+    def parse(self, stream: TokenStream) -> ast.Node:
+        expect(stream, TOKEN_TAG, value=TAG_CASE)
+        tok = stream.current
+        stream.next_token()
+
+        # Parse the case expression.
+        expect(stream, TOKEN_EXPRESSION)
+        case = self._parse_case_expression(stream.current.value, stream.current.linenum)
+        stream.next_token()
+
+        # Eat whitespace or junk between `case` and when/else/endcase
+        while (
+            stream.current.type != TOKEN_TAG
+            and stream.current.value not in ENDWHENBLOCK
+        ):
+            stream.next_token()
+
+        blocks: List[_Block] = []
+
+        while not stream.current.istag(TAG_ENDCASE):
+            if stream.current.istag(TAG_ELSE):
+                stream.next_token()
+                blocks.append(
+                    _Block(
+                        tag=TAG_ELSE,
+                        node=self.parser.parse_block(stream, ENDWHENBLOCK),
+                    )
+                )
+            elif stream.current.istag(TAG_WHEN):
+                when_tok = stream.next_token()
+                expect(stream, TOKEN_EXPRESSION)  # XXX: empty when expressions?
+
+                when_exprs = [
+                    BooleanExpression(InfixExpression(case, "==", expr))
+                    for expr in self._parse_when_expression(
+                        stream.current.value, stream.current.linenum
+                    )
+                ]
+
+                stream.next_token()
+                when_block = self.parser.parse_block(stream, ENDWHENBLOCK)
+
+                blocks.extend(
+                    _Block(
+                        tag=TAG_WHEN,
+                        node=ast.ConditionalBlockNode(
+                            tok=when_tok,
+                            condition=expr,
+                            block=when_block,
+                        ),
+                    )
+                    for expr in when_exprs
+                )
+
+            else:
+                raise LiquidSyntaxError(
+                    f"unexpected tag {stream.current.value}",
+                    linenum=stream.current.linenum,
+                )
+
+        expect(stream, TOKEN_TAG, value=TAG_ENDCASE)
+        return LaxCaseNode(tok, blocks=blocks)

--- a/liquid/golden/case_tag.py
+++ b/liquid/golden/case_tag.py
@@ -143,17 +143,6 @@ cases = [
         globals={"title": "Hello"},
     ),
     Case(
-        description="mix or and comma separated when expression",
-        template=(
-            r"{% case title %}"
-            r"{% when 'foo' %}foo"
-            r"{% when 'bar' or 'Hello', 'Hello' %}bar"
-            r"{% endcase %}"
-        ),
-        expect="barbar",
-        globals={"title": "Hello"},
-    ),
-    Case(
         description="unexpected when token",
         template=(
             r"{% case title %}"
@@ -187,5 +176,44 @@ cases = [
         template="{% case x %}{% when y %}foo{% endcase %}",
         expect="foo",
         globals={"x": ["a", "b", "c"], "y": ["a", "b", "c"]},
+    ),
+    Case(
+        description="multiple else blocks",
+        template=(
+            r"{% case 'x' %}{% when 'y' %}foo{% else %}bar{% else %}baz{% endcase %}"
+        ),
+        expect="barbaz",
+        globals={},
+        future=True,
+    ),
+    Case(
+        description="falsy when before and truthy when after else",
+        template=(
+            r"{% case 'x' %}{% when 'y' %}foo{% else %}bar"
+            r"{% when 'x' %}baz{% endcase %}"
+        ),
+        expect="barbaz",
+        globals={},
+        future=True,
+    ),
+    Case(
+        description="falsy when before and truthy when after multiple else blocks",
+        template=(
+            r"{% case 'x' %}{% when 'y' %}foo{% else %}bar"
+            r"{% else %}baz{% when 'x' %}qux{% endcase %}"
+        ),
+        expect="barbazqux",
+        globals={},
+        future=True,
+    ),
+    Case(
+        description="truthy when before and after else",
+        template=(
+            r"{% case 'x' %}{% when 'x' %}foo"
+            r"{% else %}bar{% when 'x' %}baz{% endcase %}"
+        ),
+        expect="foobaz",
+        globals={},
+        future=True,
     ),
 ]

--- a/liquid/golden/case_tag.py
+++ b/liquid/golden/case_tag.py
@@ -216,4 +216,11 @@ cases = [
         globals={},
         future=True,
     ),
+    Case(
+        description="truthy and empty when block before else",
+        template=(r"{% case 'x' %}{% when 'x' %}{% else %}bar{% endcase %}"),
+        expect="",
+        globals={},
+        future=True,
+    ),
 ]


### PR DESCRIPTION
Add a Shopify compatible implementation of the `case` tag. Closes #154.

This new "lax" `case` tag is enabled in [`liquid.future.Environment`](https://jg-rp.github.io/liquid/api/future-environment). The default `Environment` is unchanged.