### PR TITLE
Handle interrupts in tablerow tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Fixed `{% case %}` / `{% when %}` behavior. When using [`liquid.future.Environment`](https://jg-rp.github.io/liquid/api/future-environment), we now render any number of `{% else %}` blocks and allow `{% when %}` tags to appear after `{% else %}` tags. The default `Environment` continues to raise a `LiquidSyntaxError` in such cases.
 
+**Changed**
+
+- Changed `{% break %}` and `{% continue %}` tag handling when they appear inside a `{% tablerow %}` tag. Now, when using `liquid.future.Environment`, interrupts follow Shopify/Liquid behavior introduced in [#1818](https://github.com/Shopify/liquid/pull/1818). Python Liquid's default environment is unchanged.
+
 ## Version 1.12.1
 
 **Fixes**

--- a/liquid/context.py
+++ b/liquid/context.py
@@ -72,9 +72,7 @@ class BuiltIn(Mapping[str, object]):
     """Mapping-like object for resolving built-in, dynamic objects."""
 
     def __contains__(self, item: object) -> bool:
-        if item in ("now", "today"):
-            return True
-        return False
+        return item in ("now", "today")
 
     def __getitem__(self, key: str) -> object:
         if key == "now":

--- a/liquid/expression.py
+++ b/liquid/expression.py
@@ -1,4 +1,5 @@
 """Liquid expression objects."""
+
 from __future__ import annotations
 
 import sys
@@ -79,9 +80,7 @@ class Empty(Expression):
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Empty):
             return True
-        if isinstance(other, (list, dict, str)) and not other:
-            return True
-        return False
+        return isinstance(other, (list, dict, str)) and not other
 
     def __repr__(self) -> str:  # pragma: no cover
         return "Empty()"
@@ -107,9 +106,7 @@ class Blank(Expression):
             return True
         if isinstance(other, (list, dict)) and not other:
             return True
-        if isinstance(other, Blank):
-            return True
-        return False
+        return isinstance(other, Blank)
 
     def __repr__(self) -> str:  # pragma: no cover
         return "Blank()"
@@ -131,9 +128,7 @@ class Continue(Expression):
     __slots__ = ()
 
     def __eq__(self, other: object) -> bool:
-        if isinstance(other, Continue):
-            return True
-        return False
+        return isinstance(other, Continue)
 
     def __repr__(self) -> str:  # pragma: no cover
         return "Continue()"
@@ -1106,7 +1101,7 @@ def compare(left: object, op: str, right: object) -> bool:  # noqa: PLR0911, PLR
         right = right.__liquid__()
 
     def _type_error(_left: object, _right: object) -> NoReturn:
-        if type(_left) != type(_right):
+        if type(_left) != type(_right):  # noqa: E721
             raise LiquidTypeError(f"invalid operator for types '{_left} {op} {_right}'")
 
         raise LiquidTypeError(f"unknown operator: {type(_left)} {op} {type(_right)}")

--- a/liquid/future/environment.py
+++ b/liquid/future/environment.py
@@ -6,6 +6,7 @@ template rendering behavior.
 from ..environment import Environment as DefaultEnvironment
 from ..template import FutureBoundTemplate
 from .filters import split
+from .tags import InterruptingTablerowTag
 from .tags import LaxCaseTag
 from .tags import LaxIfTag
 from .tags import LaxUnlessTag
@@ -31,3 +32,4 @@ class Environment(DefaultEnvironment):
         self.add_tag(LaxCaseTag)
         self.add_tag(LaxIfTag)
         self.add_tag(LaxUnlessTag)
+        self.add_tag(InterruptingTablerowTag)

--- a/liquid/future/tags/__init__.py
+++ b/liquid/future/tags/__init__.py
@@ -1,8 +1,10 @@
 from ._case_tag import LaxCaseTag  # noqa: D104
 from ._if_tag import LaxIfTag
+from ._tablerow_tag import InterruptingTablerowTag
 from ._unless_tag import LaxUnlessTag
 
 __all__ = (
+    "InterruptingTablerowTag",
     "LaxCaseTag",
     "LaxIfTag",
     "LaxUnlessTag",

--- a/liquid/future/tags/_tablerow_tag.py
+++ b/liquid/future/tags/_tablerow_tag.py
@@ -1,0 +1,14 @@
+from liquid.builtin.tags.tablerow_tag import TablerowNode
+from liquid.builtin.tags.tablerow_tag import TablerowTag
+
+
+class InterruptingTablerowNode(TablerowNode):
+    """A _tablerow_ node with interrupt handling enabled."""
+
+    interrupts = True
+
+
+class InterruptingTablerowTag(TablerowTag):
+    """A _tablerow_ tag that handles `break` and `continue` tags."""
+
+    node_class = InterruptingTablerowNode

--- a/liquid/golden/tablerow_tag.py
+++ b/liquid/golden/tablerow_tag.py
@@ -282,6 +282,61 @@ cases = [
             "</tr>\n"
         ),
     ),
+    Case(
+        description="break from a tablerow loop",
+        template=(
+            r"{% tablerow n in (1..3) cols:2 %}"
+            r"{{n}}{% break %}{{n}}"
+            r"{% endtablerow %}"
+        ),
+        expect='<tr class="row1">\n<td class="col1">1</td></tr>\n',
+        future=True,
+    ),
+    Case(
+        description="continue from a tablerow loop",
+        template=(
+            r"{% tablerow n in (1..3) cols:2 %}"
+            r"{{n}}{% continue %}{{n}}"
+            r"{% endtablerow %}"
+        ),
+        expect=(
+            '<tr class="row1">\n'
+            '<td class="col1">1</td>'
+            '<td class="col2">2</td>'
+            "</tr>\n"
+            '<tr class="row2">'
+            '<td class="col1">3</td>'
+            "</tr>\n"
+        ),
+        future=True,
+    ),
+    Case(
+        description="break from a tablerow loop inside a for loop",
+        template=(
+            r"{% for i in (1..2) -%}\n"
+            r"{% for j in (1..2) -%}\n"
+            r"{% tablerow k in (1..3) %}{% break %}{% endtablerow -%}\n"
+            r"loop j={{ j }}\n"
+            r"{% endfor -%}\n"
+            r"loop i={{ i }}\n"
+            r"{% endfor -%}\n"
+            r"after loop\n"
+        ),
+        expect="\n".join(
+            [
+                r'\n\n<tr class="row1">',
+                r'<td class="col1"></td></tr>',
+                r'\nloop j=1\n\n<tr class="row1">',
+                r'<td class="col1"></td></tr>',
+                r'\nloop j=2\n\nloop i=1\n\n\n<tr class="row1">',
+                r'<td class="col1"></td></tr>',
+                r'\nloop j=1\n\n<tr class="row1">',
+                r'<td class="col1"></td></tr>',
+                r"\nloop j=2\n\nloop i=2\n\nafter loop\n",
+            ]
+        ),
+        future=True,
+    ),
     # Case(
     #     description="cols is non number string",
     #     template=(

--- a/liquid/parse.py
+++ b/liquid/parse.py
@@ -615,7 +615,6 @@ class ExpressionParser:
         filter_name = stream.current.value
         stream.next_token()
 
-        #
         args = []
         kwargs = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "hatchling.build"
 requires = ["hatchling"]
 
 [project]
-authors = [{name = "James Prior", email = "jamesgr.prior@gmail.com"}]
+authors = [{ name = "James Prior", email = "jamesgr.prior@gmail.com" }]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -18,7 +18,11 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
 ]
-dependencies = ["python-dateutil>=2.8.1", "typing-extensions>=4.2.0", "importlib-resources>=5.10.0"]
+dependencies = [
+  "python-dateutil>=2.8.1",
+  "typing-extensions>=4.2.0",
+  "importlib-resources>=5.10.0",
+]
 description = "A Python engine for the Liquid template language."
 dynamic = ["version"]
 license = "MIT"
@@ -126,49 +130,6 @@ warn_unused_configs = true
 warn_unused_ignores = false
 
 [tool.ruff]
-select = [
-  "A",
-  "ARG",
-  "B",
-  "BLE",
-  "C4",
-  "D",
-  "E",
-  "F",
-  "I",
-  "ICN",
-  "ISC",
-  "N",
-  "PIE",
-  "PL",
-  "PT",
-  "Q",
-  "RET",
-  "RSE",
-  "S",
-  "SIM",
-  "SLF",
-  "T10",
-  "T20",
-  "TCH",
-  "YTT",
-]
-# TODO: review ignores
-ignore = [
-  "S105",
-  "S101",
-  "D107",
-  "D105",
-  "PLR0913",
-  "D401",
-  "N818",
-  "PT009",
-  "B905",
-  "PT027",
-]
-
-fixable = ["I", "SIM", "D202"]
-unfixable = []
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -197,19 +158,16 @@ exclude = [
 # Same as Black.
 line-length = 88
 
-# Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
 # Assume Python 3.10.
 target-version = "py310"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-single-line = true
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "liquid/__about__.py" = ["D100"]
 "liquid/__init__.py" = ["D104", "I001"]
 "liquid/builtin/filters/__init__.py" = ["D104", "I001"]
@@ -217,3 +175,52 @@ convention = "google"
 "liquid/builtin/tags/__init__.py" = ["D104", "I001"]
 "scripts/__init__.py" = ["D104", "I001"]
 "tests/*" = ["D100", "D101", "D104", "D103", "D102", "D209", "D205", "SIM117"]
+
+[tool.ruff.lint]
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+select = [
+  "A",
+  "ARG",
+  "B",
+  "BLE",
+  "C4",
+  "D",
+  "E",
+  "F",
+  "I",
+  "ICN",
+  "ISC",
+  "N",
+  "PIE",
+  "PL",
+  "PT",
+  "Q",
+  "RET",
+  "RSE",
+  "S",
+  "SIM",
+  "SLF",
+  "T10",
+  "T20",
+  "TCH",
+  "YTT",
+]
+
+# TODO: review ignores
+ignore = [
+  "S105",
+  "S101",
+  "D107",
+  "D105",
+  "PLR0913",
+  "D401",
+  "N818",
+  "PT009",
+  "B905",
+  "PT027",
+]
+
+fixable = ["I", "SIM", "D202"]
+unfixable = []

--- a/tests/filters/test_misc.py
+++ b/tests/filters/test_misc.py
@@ -1,4 +1,5 @@
 """Test miscellaneous filter functions."""
+
 import datetime
 import decimal
 import platform
@@ -32,9 +33,7 @@ class MockDrop:  # pragma: no cover
         self.val = val
 
     def __eq__(self, other):
-        if isinstance(other, MockDrop) and self.val == other.val:
-            return True
-        return False
+        return bool(isinstance(other, MockDrop) and self.val == other.val)
 
     def __str__(self):
         return "hello mock drop"
@@ -48,9 +47,7 @@ class NoLiquidDrop:  # pragma: no cover
         self.val = val
 
     def __eq__(self, other):
-        if isinstance(other, NoLiquidDrop) and self.val == other.val:
-            return True
-        return False
+        return bool(isinstance(other, NoLiquidDrop) and self.val == other.val)
 
     def __str__(self):
         return "hello no liquid drop"
@@ -63,9 +60,7 @@ class FalsyDrop:  # pragma: no cover
     def __eq__(self, other):
         if isinstance(other, bool) and self.val == other:
             return True
-        if isinstance(other, FalsyDrop) and self.val == other.val:
-            return True
-        return False
+        return bool(isinstance(other, FalsyDrop) and self.val == other.val)
 
     def __str__(self):
         return "falsy drop"


### PR DESCRIPTION
This PR changes the behaviour of the `{% tablerow %}` tag in the `liquid.future.Environment` (the default environment remains unchanged). 

`{% tablerow %}` has been changed to handle `{% break %}` and `{% continue %}` tags, as introduced in https://github.com/Shopify/liquid/pull/1818.