### PR TITLE
Test against Python version 3.13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           - os: macos-latest
             python-version: "3.7"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,12 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.7.17", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           - os: macos-latest
-            python-version: "3.7"
+            python-version: "3.7.17"
           - os: windows-latest
-            python-version: "3.7"
+            python-version: "3.7.17"
           - os: macos-latest
             python-version: "3.8"
           - os: windows-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,12 +9,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           - os: macos-latest
             python-version: "3.7"
           - os: windows-latest
             python-version: "3.7"
+          - os: macos-latest
+            python-version: "3.8"
+          - os: windows-latest
+            python-version: "3.8"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.3"]
         exclude:
           - os: macos-latest
             python-version: "3.7"

--- a/liquid/builtin/filters/string.py
+++ b/liquid/builtin/filters/string.py
@@ -1,4 +1,5 @@
 """Filter functions that operate on strings."""
+
 from __future__ import annotations
 
 import base64

--- a/liquid/builtin/loaders/base_loader.py
+++ b/liquid/builtin/loaders/base_loader.py
@@ -1,4 +1,5 @@
 """Base template loader."""
+
 from __future__ import annotations
 
 from abc import ABC
@@ -48,7 +49,7 @@ class BaseLoader(ABC):  # noqa: B024
 
     Attributes:
         caching_loader (bool): Indicates if this loader implements its own cache.
-            Setting this sto `True` will cause the `Environment` to disable its cache
+            Setting this to `True` will cause the `Environment` to disable its cache
             when initialized with a caching loader.
     """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 
 [project.optional-dependencies]
-autoescape = ["MarkupSafe>=2.0.0"]
+autoescape = ["MarkupSafe>=2,<3"]
 
 [project.urls]
 "Change Log" = "https://github.com/jg-rp/liquid/blob/main/CHANGES.md"
@@ -64,7 +64,7 @@ dependencies = [
   "ruff",
   "mock",
   "types-python-dateutil",
-  "MarkupSafe",
+  "MarkupSafe>=2, < 3",
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
   "python-dateutil>=2.8.1",


### PR DESCRIPTION
Test against Python version 3.13 and exclude Markupsafe version 3.

The new behaviour in Markupsafe version 3 does look better, but is a breaking change for some Liquid filters, so we'll pin version 2 only.
