### PR TITLE
Optionally allow shorthand indexes in variable paths

### DIFF
--- a/liquid/builtin/tags/case_tag.py
+++ b/liquid/builtin/tags/case_tag.py
@@ -1,4 +1,5 @@
 """Tag and node definition for the built-in "case" tag."""
+
 from __future__ import annotations
 
 import sys
@@ -193,14 +194,16 @@ class CaseTag(Tag):
 
     def _parse_case_expression(self, expr: str, linenum: int) -> Expression:
         stream = ExpressionTokenStream(
-            tokenize_common_expression(expr, linenum=linenum)
+            tokenize_common_expression(expr, linenum=linenum),
+            shorthand_indexes=self.env.shorthand_indexes,
         )
         return parse_common_expression(stream)
 
     def _parse_when_expression(self, expr: str, linenum: int) -> List[Expression]:
         expressions = []
         stream = ExpressionTokenStream(
-            tokenize_common_expression(expr, linenum=linenum)
+            tokenize_common_expression(expr, linenum=linenum),
+            shorthand_indexes=self.env.shorthand_indexes,
         )
 
         while True:

--- a/liquid/environment.py
+++ b/liquid/environment.py
@@ -14,7 +14,6 @@ from typing import Iterator
 from typing import Mapping
 from typing import MutableMapping
 from typing import Optional
-from typing import Protocol
 from typing import Tuple
 from typing import Type
 from typing import Union
@@ -585,12 +584,12 @@ class Environment:
     def _get_expression_parsers(
         self, cache_size: int = 0
     ) -> Tuple[
-        BooleanExprParserCallable,
-        BooleanExprParserCallable,
-        FilteredExprParserCallable,
-        FilteredExprParserCallable,
-        FilteredExprParserCallable,
-        LoopExprParserCallable,
+        Callable[[str, int], BooleanExpression],
+        Callable[[str, int], BooleanExpression],
+        Callable[[str, int], FilteredExpression],
+        Callable[[str, int], FilteredExpression],
+        Callable[[str, int], FilteredExpression],
+        Callable[[str, int], LoopExpression],
     ]:
         if cache_size >= 1:
             return (
@@ -793,33 +792,3 @@ def Template(  # noqa: N802, D417
     )
 
     return env.from_string(source, globals=globals)
-
-
-class FilteredExprParserCallable(Protocol):
-    """The signature for filter expression parser callables."""
-
-    def __call__(
-        self, expr: str, linenum: int = 1, *, shorthand_indexes: bool = False
-    ) -> FilteredExpression:
-        """Parse _expr_."""
-        ...
-
-
-class LoopExprParserCallable(Protocol):
-    """The signature for loop expression parser callables."""
-
-    def __call__(
-        self, expr: str, linenum: int = 1, *, shorthand_indexes: bool = False
-    ) -> LoopExpression:
-        """Parse _expr_."""
-        ...
-
-
-class BooleanExprParserCallable(Protocol):
-    """The signature for Boolean expression parser callables."""
-
-    def __call__(
-        self, expr: str, linenum: int = 1, *, shorthand_indexes: bool = False
-    ) -> BooleanExpression:
-        """Parse _expr_."""
-        ...

--- a/liquid/expressions/boolean/parse.py
+++ b/liquid/expressions/boolean/parse.py
@@ -1,4 +1,5 @@
 """Functions for parsing boolean expressions."""
+
 from typing import Callable
 from typing import Dict
 
@@ -188,9 +189,15 @@ parse_range = make_parse_range(parse_simple_obj)
 TOKEN_MAP[TOKEN_LPAREN] = parse_range
 
 
-def parse(expr: str, linenum: int = 1) -> BooleanExpression:
+def parse(
+    expr: str, linenum: int = 1, *, shorthand_indexes: bool = False
+) -> BooleanExpression:
     """Parse a string as a "standard" boolean expression."""
-    return BooleanExpression(parse_obj(TokenStream(tokenize(expr, linenum))))
+    return BooleanExpression(
+        parse_obj(
+            TokenStream(tokenize(expr, linenum), shorthand_indexes=shorthand_indexes)
+        )
+    )
 
 
 def parse_grouped_expression(stream: TokenStream) -> Expression:
@@ -261,13 +268,17 @@ def parse_obj_with_parens(
     return left
 
 
-def parse_with_parens(expr: str, linenum: int = 1) -> BooleanExpression:
+def parse_with_parens(
+    expr: str, linenum: int = 1, *, shorthand_indexes: bool = False
+) -> BooleanExpression:
     """Parse a string as a boolean expression.
 
     This function handles expressions containing the logical `not` operator and
     parentheses for grouping terms.
     """
-    stream = TokenStream(tokenize_with_parens(expr, linenum))
+    stream = TokenStream(
+        tokenize_with_parens(expr, linenum), shorthand_indexes=shorthand_indexes
+    )
     rv = BooleanExpression(parse_obj_with_parens(stream))
     peek_typ = stream.peek[1]
     if peek_typ == TOKEN_RPAREN:

--- a/liquid/expressions/loop/parse.py
+++ b/liquid/expressions/loop/parse.py
@@ -2,6 +2,7 @@
 
 Like those found in `for` and `tablerow` tags.
 """
+
 from typing import Callable
 from typing import Dict
 from typing import Tuple
@@ -109,9 +110,11 @@ def parse_loop_arguments(stream: TokenStream) -> Tuple[Dict[str, LoopArgument], 
     return arguments, _reversed
 
 
-def parse(expr: str, linenum: int = 1) -> LoopExpression:
+def parse(
+    expr: str, linenum: int = 1, *, shorthand_indexes: bool = False
+) -> LoopExpression:
     """Parse a loop expression string."""
-    stream = TokenStream(tokenize(expr, linenum))
+    stream = TokenStream(tokenize(expr, linenum), shorthand_indexes=shorthand_indexes)
     stream.expect(TOKEN_IDENTIFIER)
     name = next(stream)[2]
 

--- a/liquid/expressions/stream.py
+++ b/liquid/expressions/stream.py
@@ -19,12 +19,14 @@ if TYPE_CHECKING:
 class TokenStream:
     """Step through or iterate a stream of tokens."""
 
-    def __init__(self, tokeniter: Iterator[Token]):
+    def __init__(self, tokeniter: Iterator[Token], *, shorthand_indexes: bool = False):
         self.iter = tokeniter
         self._pushed: Deque[Token] = deque()
 
         self.current: Token = (0, TOKEN_INITIAL, "")
         next(self)
+
+        self.shorthand_indexes = shorthand_indexes
 
     class TokenStreamIterator:
         """An iterable token stream."""

--- a/liquid/extra/tags/if_not.py
+++ b/liquid/extra/tags/if_not.py
@@ -6,7 +6,6 @@ logical `not` operator and grouping terms with parentheses.
 
 from liquid.builtin.tags.if_tag import IfTag
 from liquid.expression import Expression
-from liquid.expressions import parse_boolean_expression_with_parens
 from liquid.parse import expect
 from liquid.stream import TokenStream
 from liquid.token import TOKEN_EXPRESSION
@@ -20,6 +19,6 @@ class IfNotTag(IfTag):
     def parse_expression(self, stream: TokenStream) -> Expression:
         """Pare a boolean expression from a stream of tokens."""
         expect(stream, TOKEN_EXPRESSION)
-        return parse_boolean_expression_with_parens(
+        return self.env.parse_boolean_expression_value_with_parens(
             stream.current.value, stream.current.linenum
         )

--- a/tests/test_shorthand_indexes.py
+++ b/tests/test_shorthand_indexes.py
@@ -1,0 +1,81 @@
+import pytest
+
+from liquid import Environment
+from liquid.exceptions import LiquidSyntaxError
+from liquid.extra import add_inline_expression_tags
+from liquid.extra.tags import IfNotTag
+
+
+def test_shorthand_indexes_with_default_environment() -> None:
+    env = Environment()
+    with pytest.raises(LiquidSyntaxError):
+        env.from_string("{{ foo.0.bar }}")
+
+
+class MockEnv(Environment):
+    shorthand_indexes = True
+
+
+ENV = MockEnv()
+
+
+def test_shorthand_index() -> None:
+    data = {"foo": ["World", "Liquid"]}
+    template = ENV.from_string("Hello, {{ foo.0 }}!")
+    assert template.render(**data) == "Hello, World!"
+    template = ENV.from_string("Hello, {{ foo.1 }}!")
+    assert template.render(**data) == "Hello, Liquid!"
+
+
+def test_consecutive_shorthand_indexes() -> None:
+    data = {"foo": [["World", "Liquid"]]}
+    template = ENV.from_string("Hello, {{ foo.0.0 }}!")
+    assert template.render(**data) == "Hello, World!"
+    template = ENV.from_string("Hello, {{ foo.0.1 }}!")
+    assert template.render(**data) == "Hello, Liquid!"
+
+
+def test_shorthand_index_dot_property() -> None:
+    data = {"foo": [{"bar": "World"}, {"bar": "Liquid"}]}
+    template = ENV.from_string("Hello, {{ foo.0.bar }}!")
+    assert template.render(**data) == "Hello, World!"
+    template = ENV.from_string("Hello, {{ foo.1.bar }}!")
+    assert template.render(**data) == "Hello, Liquid!"
+
+
+def test_shorthand_index_in_loop_expression() -> None:
+    data = {"foo": [["World", "Liquid"]]}
+    template = ENV.from_string("{% for x in foo.0 %}Hello, {{ x }}! {% endfor %}")
+    assert template.render(**data) == "Hello, World! Hello, Liquid! "
+
+
+def test_shorthand_index_in_conditional_expression() -> None:
+    data = {"foo": ["World", "Liquid"]}
+    template = ENV.from_string("{% if foo.0 %}Hello, {{ foo.0 }}!{% endif %}")
+    assert template.render(**data) == "Hello, World!"
+    template = ENV.from_string("{% if foo.2 %}Hello, {{ foo.2 }}!{% endif %}")
+    assert template.render(**data) == ""
+
+
+def test_shorthand_indexes_in_ternary_expressions() -> None:
+    env = MockEnv()
+    add_inline_expression_tags(env)
+
+    data = {"foo": ["World", "Liquid"]}
+    template = env.from_string("Hello, {{ foo.0 }}!")
+    assert template.render(**data) == "Hello, World!"
+    template = env.from_string("Hello, {{ 'you' if foo.1 }}!")
+    assert template.render(**data) == "Hello, you!"
+    template = env.from_string("Hello, {{ 'you' if foo.99 else foo.1 }}!")
+    assert template.render(**data) == "Hello, Liquid!"
+
+
+def test_shorthand_indexes_in_logical_not_expressions() -> None:
+    env = MockEnv()
+    env.add_tag(IfNotTag)
+
+    data = {"foo": ["World", "Liquid"]}
+    template = env.from_string("{% if not foo.0 %}Hello, {{ foo.0 }}!{% endif %}")
+    assert template.render(**data) == ""
+    template = env.from_string("{% if not foo.2 %}Hello, {{ foo.0 }}!{% endif %}")
+    assert template.render(**data) == "Hello, World!"

--- a/tests/test_shorthand_indexes.py
+++ b/tests/test_shorthand_indexes.py
@@ -57,6 +57,14 @@ def test_shorthand_index_in_conditional_expression() -> None:
     assert template.render(**data) == ""
 
 
+def test_shorthand_indexes_in_case_tag() -> None:
+    data = {"foo": ["World", "Liquid"]}
+    template = ENV.from_string(
+        "{% case foo.0 %}{% when 'World' %}Hello, World!{% endcase %}"
+    )
+    assert template.render(**data) == "Hello, World!"
+
+
 def test_shorthand_indexes_in_ternary_expressions() -> None:
     env = MockEnv()
     add_inline_expression_tags(env)


### PR DESCRIPTION
This PR adds a `shorthand_indexes` class variable to `liquid.Environment`. When `shorthand_indexes` is set to `True` (default is `False`), array indexes in variable paths need not be surrounded by square brackets.

In a future release we'll refactor expression parsing to make sure the current environment is available to all expression parsing functions/methods so we don't need to pass a `shorthand_indexes` argument in a million places.

See #39.

```python
from liquid import Environment

class MyEnv(Environment):
    shorthand_indexes = True

env = MyEnv()

data = {"foo": ["World", "Liquid"]}
template = env.from_string("Hello, {{ foo.0 }}!")
print(template) # Hello, World!
```

**TODO:**

- [x] Docs
- [x] Common expression parser
- [x] Macro and call arguments