### PR TITLE
Conditional expressions and Boolean operators

### DIFF
--- a/liquid/builtin/expressions/logical.py
+++ b/liquid/builtin/expressions/logical.py
@@ -210,14 +210,12 @@ class LogicalAndExpression(Expression):
         return f"{self.left} and {self.right}"
 
     def evaluate(self, context: RenderContext) -> object:
-        return is_truthy(self.left.evaluate(context)) and is_truthy(
-            self.right.evaluate(context)
-        )
+        left = self.left.evaluate(context)
+        return self.right.evaluate(context) if is_truthy(left) else left
 
     async def evaluate_async(self, context: RenderContext) -> object:
-        return is_truthy(await self.left.evaluate_async(context)) and is_truthy(
-            await self.right.evaluate_async(context)
-        )
+        left = await self.left.evaluate_async(context)
+        return await self.right.evaluate_async(context) if is_truthy(left) else left
 
     def children(self) -> list[Expression]:
         return [self.left, self.right]
@@ -235,14 +233,12 @@ class LogicalOrExpression(Expression):
         return f"{self.left} or {self.right}"
 
     def evaluate(self, context: RenderContext) -> object:
-        return is_truthy(self.left.evaluate(context)) or is_truthy(
-            self.right.evaluate(context)
-        )
+        left = self.left.evaluate(context)
+        return left if is_truthy(left) else self.right.evaluate(context)
 
     async def evaluate_async(self, context: RenderContext) -> object:
-        return is_truthy(await self.left.evaluate_async(context)) or is_truthy(
-            await self.right.evaluate_async(context)
-        )
+        left = await self.left.evaluate_async(context)
+        return left if is_truthy(left) else await self.right.evaluate_async(context)
 
     def children(self) -> list[Expression]:
         return [self.left, self.right]


### PR DESCRIPTION
It looks like Shopify are considering/experimenting with conditional expressions in Liquid. Here we're talking about _in line_ control structures that can be used in output statements, assignment expressions and as arguments to tags and filters.

In these locations, Liquid currently supports:

- literals (strings, integers, floats, `true`, `false`, `nil`/`null`)
- range expressions\* (`(1..5)`)
- variables names/paths (`foo.bar[0]`)
- reserved words (`empty`, `blank`)

Collectively, in Python Liquid, we call these _primitive expressions_. They are the small building blocks that make up all other expressions.

[Shopify/Liquid #1922](https://github.com/Shopify/liquid/pull/1922) (draft) adds support for _compound expressions_ in output statements, assignment expressions and as arguments to tags and filters. These compound expressions combine primitives with Boolean operators (`and` and `or`) and/or comparison operators (`==`, `>`, `>=`, etc.).

### Boolean operator semantics

In this example, the variable `x` will be set to the value at `a` if `a` is truthy, or the value at `b` if `a` is falsy.

```liquid
{% assign x = a or b %}
```

This is logically equivalent to `if a then a else b` or `a if a else b` using ternary condition syntax.

And here, with the `and` operator, the variable `x` will be set to the value at `b` if `a` is truthy, or the value at `a` if `a` is falsy, which is logically equivalent to `if a then b else a` or `b if a else a` using ternary condition syntax.

```liquid
{% assign x = a and b %}
```

With [short-circuit evaluation](https://en.wikipedia.org/wiki/Short-circuit_evaluation), these Boolean operator semantics are sometimes called "last value", as the result is the value of the last sub expression to be evaluated.

> [!NOTE]
> Outstanding issue [Shopify/liquid #1034](https://github.com/Shopify/liquid/issues/1034) might limit the usefulness of in line Boolean operators for some deployments.

### This experiment

As we already support ternary condition syntax, we'll conceptually treat expressions including Boolean operators as a shorthand form of the more general ternary expression.

We'll define a _primary expression_ to replace most instances of _primitive expression_ that is effectively equivalent to the current `parse_logical_primitive()` function, just that the resulting expression evaluates to the _last value_ rather than a Boolean.

Existing comparison operators should work unchanged, because they always evaluate to a Boolean value.
