### PR TITLE
Update golden liquid and change `map` filter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Python Liquid Change Log
 
+## Version 2.0.2
+
+- Fixed the `map` filter when it's given a `nil`/`null` or undefined argument. The input sequence is now returned in such cases. This change was introduced in [Shopify/liquid #1944](https://github.com/Shopify/liquid/pull/1944).
+
 ## Version 2.0.1
 
 - Fixed bad imports from `typing_extensions`.

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -56,7 +56,7 @@ from .tag import Tag
 
 from . import future
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 __all__ = (
     "AwareBoundTemplate",

--- a/liquid/builtin/filters/array.py
+++ b/liquid/builtin/filters/array.py
@@ -107,8 +107,11 @@ def concat(sequence: ArrayT, second_array: ArrayT) -> ArrayT:
 
 
 @sequence_filter
-def map_(sequence: ArrayT, key: object) -> list[object]:
+def map_(sequence: ArrayT, key: object) -> Union[list[object], tuple[object]]:
     """Return an array/list of items in _sequence_ selected by _key_."""
+    if key is None or is_undefined(key):
+        return sequence
+
     try:
         return [_getitem(itm, str(key), default=_NULL) for itm in sequence]
     except TypeError as err:

--- a/tests/filters/test_map_.py
+++ b/tests/filters/test_map_.py
@@ -81,7 +81,7 @@ TEST_CASES = [
         val=[{"title": "foo"}, {"title": "bar"}, {"title": "baz"}],
         args=[ENV.undefined("test")],
         kwargs={},
-        expect=[None, None, None],
+        expect=[{"title": "foo"}, {"title": "bar"}, {"title": "baz"}],
     ),
 ]
 


### PR DESCRIPTION
This PR fixes the `map` filter when it's given a `nil`/`null` or undefined argument. The input sequence is now returned in such cases.

This change was introduced in [Shopify/liquid #1944](https://github.com/Shopify/liquid/pull/1944).