### PR TITLE
Fix for loop iterable fallback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Fixed static analysis of filters in ternary expressions. See [#180](https://github.com/jg-rp/liquid/issues/180).
 - Fixed static analysis of macro blocks. Previously `args` and `kwargs` were considered "global". See [#181](https://github.com/jg-rp/liquid/issues/181).
+- Fixed looping over non-iterable objects with the `{% for %}` tag. We were raising a `LiquidTypeError` when we should have been defaulting to an empty iterable, as Shopify/Liquid does.
 
 ## Version 2.0.1
 

--- a/liquid/builtin/expressions/loop.py
+++ b/liquid/builtin/expressions/loop.py
@@ -97,14 +97,11 @@ class LoopExpression(Expression):
         if isinstance(obj, range):
             return iter(obj), len(obj)
         if isinstance(obj, str) and not context.env.string_sequences:
-            return iter([obj]), 1
+            return (iter([]), 0) if not obj else (iter([obj]), 1)
         if isinstance(obj, Sequence):
             return iter(obj), len(obj)
 
-        raise LiquidTypeError(
-            f"expected an iterable at '{self.iterable}', found '{obj}'",
-            token=self.token,
-        )
+        return iter([]), 0
 
     def _to_int(self, obj: object, *, token: Token) -> int:
         try:


### PR DESCRIPTION
This PR fixes looping over non-iterable objects with the `{% for %}` tag. We were raising a `LiquidTypeError` when we should have been defaulting to an empty iterable, as Shopify/Liquid does.

