### PR TITLE
Fix docs typo and ignore ruff PLW1641

### DIFF
--- a/docs/filter_reference.md
+++ b/docs/filter_reference.md
@@ -1,4 +1,4 @@
-All the filters described here are enabled by default in Python Liquid2.
+All the filters described here are enabled by default in Python Liquid.
 
 ## abs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ ignore = [
   "PLR2004",
   "S704",
   "TC006",
+  "PLW1641",
 ]
 
 fixable = ["I", "SIM", "D202"]


### PR DESCRIPTION
Ignore [Ruff PLW1641](https://docs.astral.sh/ruff/rules/eq-without-hash/) for now. I don't want these classes to be hashable.