### PR TITLE
Add new `squish` filter

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,12 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
-          - os: macos-latest
-            python-version: "3.9"
-          - os: windows-latest
-            python-version: "3.9"
           - os: macos-latest
             python-version: "3.10"
           - os: windows-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
 ## Version 2.2.0 (unreleased)
 
-- Added an **experimental** `{% snippet %}` tag. Shopify/liquid released then quickly removed `{% snippet %}`. We're calling it "experimental" and keeping it disabled by default, pending more activity from Shopify/liquid.
-- Added the `squish` filter. `{{ x | squish }}` is equivalent to `{{ x | strip | split | join}}`.
+- Added the `squish` filter. `{{ x | squish }}` is equivalent to `{{ x | strip | split | join }}`. See [#195](https://github.com/jg-rp/liquid/pull/195).
+- Added an **experimental** `{% snippet %}` tag. Shopify/liquid released then quickly removed `{% snippet %}`. We're calling it "experimental" and keeping it disabled by default, pending more activity from Shopify/liquid. See [#191](https://github.com/jg-rp/liquid/pull/191) and [#193](https://github.com/jg-rp/liquid/pull/193).
 - Improved static analysis of partial templates. Previously we would visit a partial template only once, regardless of how many times it is rendered with `{% render %}`. Now we visit partial templates once for each distinct set of arguments passed to `{% render %}`, potentially reporting "global" variables that we'd previously missed.
 - Changed the `string_filter` decorator to coerce `None` to an empty string instead of `"None"`. This is what Shopify/liquid does with `nil.to_s`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Version 2.2.0 (unreleased)
 
-- Added an **experimental** `{% snippet %}` tag. Shopify/liquid released then quickly removed `{% snippet %}`. We're calling it "experimental" and keeping it disabled by default pending more activity from Shopify/liquid.
+- Added an **experimental** `{% snippet %}` tag. Shopify/liquid released then quickly removed `{% snippet %}`. We're calling it "experimental" and keeping it disabled by default, pending more activity from Shopify/liquid.
+- Added the `squish` filter. `{{ x | squish }}` is equivalent to `{{ x | strip | split | join}}`.
 - Improved static analysis of partial templates. Previously we would visit a partial template only once, regardless of how many times it is rendered with `{% render %}`. Now we visit partial templates once for each distinct set of arguments passed to `{% render %}`, potentially reporting "global" variables that we'd previously missed.
+- Changed the `string_filter` decorator to coerce `None` to an empty string instead of `"None"`. This is what Shopify/liquid does with `nil.to_s`.
 
 ## Version 2.1.0
 

--- a/docs/filter_reference.md
+++ b/docs/filter_reference.md
@@ -1417,6 +1417,8 @@ H#e#l#l#o# #t#h#e#r#e
 
 ## squish
 
+**_New in version 2.2.0_**
+
 ```
 <string> | squish
 ```

--- a/docs/filter_reference.md
+++ b/docs/filter_reference.md
@@ -1415,6 +1415,22 @@ If the argument is undefined or an empty string, the input will be split at ever
 H#e#l#l#o# #t#h#e#r#e
 ```
 
+## squish
+
+```
+<string> | squish
+```
+
+Return the input string with all leading and trailing whitespace removed, and any other runs of whitespace replaced with a single space.
+
+```liquid2
+{{ "    Hello, \n\t World! \r\n" | squish }}
+```
+
+```plain title="output"
+Hello, World!
+```
+
 ## strip
 
 ```

--- a/liquid/builtin/__init__.py
+++ b/liquid/builtin/__init__.py
@@ -58,6 +58,7 @@ from .filters.string import replace_last
 from .filters.string import rstrip
 from .filters.string import slice_
 from .filters.string import split
+from .filters.string import squish
 from .filters.string import strip
 from .filters.string import strip_html
 from .filters.string import strip_newlines
@@ -175,6 +176,7 @@ def register(env: Environment) -> None:  # noqa: PLR0915
     env.add_filter("base64_decode", base64_decode)
     env.add_filter("base64_url_safe_encode", base64_url_safe_encode)
     env.add_filter("base64_url_safe_decode", base64_url_safe_decode)
+    env.add_filter("squish", squish)
 
     env.add_filter("find", find)
     env.add_filter("find_index", find_index)

--- a/liquid/builtin/filters/string.py
+++ b/liquid/builtin/filters/string.py
@@ -405,3 +405,12 @@ def base64_url_safe_decode(val: str) -> str:
         return base64.urlsafe_b64decode(val).decode()
     except binascii.Error as err:
         raise FilterError("invalid base64-encoded string", token=None) from err
+
+
+RE_WHITESPACE = re.compile(r"\s+")
+
+
+@string_filter
+def squish(val: str) -> str:
+    """Strip whitespace and replace whitespace with a single space."""
+    return RE_WHITESPACE.sub(" ", val.strip())

--- a/liquid/filter.py
+++ b/liquid/filter.py
@@ -54,8 +54,11 @@ def string_filter(_filter: FilterT) -> FilterT:
 
     @wraps(_filter)
     def wrapper(val: object, *args: Any, **kwargs: Any) -> Any:
-        if not isinstance(val, str):
+        if val is None:
+            val = ""
+        elif not isinstance(val, str):
             val = str(val)
+
         try:
             return _filter(val, *args, **kwargs)
         except TypeError as err:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,8 +144,7 @@ exclude = [
 # Same as Black.
 line-length = 88
 
-# Assume Python 3.12.
-target-version = "py312"
+target-version = "py39"
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/tests/filters/test_squish.py
+++ b/tests/filters/test_squish.py
@@ -1,0 +1,39 @@
+from liquid.builtin.filters.string import squish
+
+
+def test_leading_trailing_and_inner_space() -> None:
+    assert squish(" Hello    World!   ") == "Hello World!"
+
+
+def test_leading_trailing_space() -> None:
+    assert squish(" HelloWorld!   ") == "HelloWorld!"
+
+
+def test_just_leading_space() -> None:
+    assert squish("  HelloWorld!") == "HelloWorld!"
+
+
+def test_just_trailing_space() -> None:
+    assert squish("HelloWorld!   ") == "HelloWorld!"
+
+
+def test_just_inner_space() -> None:
+    assert squish("Hello   World!") == "Hello World!"
+
+
+def test_leading_trailing_and_inner_whitespace() -> None:
+    assert (
+        squish(" \n\t\r\nHello  \n\t\r\n \n\t\r\n World!  \n\t\r\n") == "Hello World!"
+    )
+
+
+def test_null_input() -> None:
+    assert squish(None) == ""
+
+
+def test_empty_string() -> None:
+    assert squish("") == ""
+
+
+def test_just_whitespace() -> None:
+    assert squish("  ") == ""


### PR DESCRIPTION
This PR add the new `squish` filter.

`{{ x | squish }}` is equivalent to `{{ x | strip | split | join }}`, although more efficient.

`squish` is enabled by default.

See https://github.com/Shopify/liquid/pull/2050.