### PR TITLE
refactor: simplify with tag namespace construction

### DIFF
--- a/liquid/extra/tags/_with.py
+++ b/liquid/extra/tags/_with.py
@@ -35,10 +35,12 @@ class WithNode(Node):
         self.block = block
         self.blank = self.block.blank
 
-    def render_to_output(self, context: RenderContext, buffer: TextIO) -> int:
-        namespace = {p.name: p.value.evaluate(context) for p in self.args}
-
-        with context.extend(namespace):
+    def render_to_output(
+        self,
+        context: RenderContext,
+        buffer: TextIO,
+    ) -> int:
+        with context.extend({a.name: a.value.evaluate(context) for a in self.args}):
             return self.block.render(context, buffer)
 
     async def render_to_output_async(
@@ -46,7 +48,7 @@ class WithNode(Node):
         context: RenderContext,
         buffer: TextIO,
     ) -> int:
-        namespace = {p.name: await p.value.evaluate_async(context) for p in self.args}
+        namespace = {a.name: await a.value.evaluate_async(context) for a in self.args}
         with context.extend(namespace):
             return await self.block.render_async(context, buffer)
 
@@ -56,21 +58,16 @@ class WithNode(Node):
         *,
         include_partials: bool = True,  # noqa: ARG002
     ) -> Iterable[Node]:
-        """Return this node's children."""
         yield self.block
 
     def expressions(self) -> Iterable[Expression]:
-        """Return this node's expressions."""
         yield from (arg.value for arg in self.args)
 
     def block_scope(self) -> Iterable[Identifier]:
-        """Return variables this node adds to the node's block scope."""
         yield from (Identifier(p.name, token=p.token) for p in self.args)
 
 
 class WithTag(Tag):
-    """The extra _with_ tag."""
-
     name = TAG_WITH
     end = TAG_ENDWITH
     node_class = WithNode
@@ -78,8 +75,6 @@ class WithTag(Tag):
     def parse(self, stream: TokenStream) -> Node:
         token = stream.eat(TOKEN_TAG)
         args = KeywordArgument.parse(self.env, stream.into_inner(tag=token))
-
-        # Parse the block
         block = get_parser(self.env).parse_block(stream, (TAG_ENDWITH, TOKEN_EOF))
         stream.expect(TOKEN_TAG, value=TAG_ENDWITH)
         return self.node_class(token, args=args, block=block)

--- a/liquid/extra/tags/_with.py
+++ b/liquid/extra/tags/_with.py
@@ -36,15 +36,17 @@ class WithNode(Node):
         self.blank = self.block.blank
 
     def render_to_output(self, context: RenderContext, buffer: TextIO) -> int:
-        namespace = dict(arg.evaluate(context) for arg in self.args)
+        namespace = {p.name: p.value.evaluate(context) for p in self.args}
 
         with context.extend(namespace):
             return self.block.render(context, buffer)
 
     async def render_to_output_async(
-        self, context: RenderContext, buffer: TextIO
+        self,
+        context: RenderContext,
+        buffer: TextIO,
     ) -> int:
-        namespace = dict([await arg.evaluate_async(context) for arg in self.args])
+        namespace = {p.name: await p.value.evaluate_async(context) for p in self.args}
         with context.extend(namespace):
             return await self.block.render_async(context, buffer)
 


### PR DESCRIPTION
## Summary
- Build `{% with %}` namespaces directly with dict comprehensions.
- Avoid the intermediate list allocation in the async renderer.
- Preserve existing sync/async rendering behavior.

## Testing
- `pytest -q tests/test_render_extra.py::RenderWithTagTestCase tests/test_analyze_template_tags.py::test_analyze_tags_with_extra_tag`
- `ruff check liquid/extra/tags/_with.py`
- `mypy liquid/extra/tags/_with.py`
