### PR TITLE
Fix empty file names and invalid suffixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Python Liquid Change Log
 
+## Version 2.2.2 (unreleased)
+
+**Fixes**
+
+- Fixed a bug in the built-in `FileSystemLoader` where a `ValueError` would be raised at render time if the target file name is empty or, in some cases, contains only path punctuation **and** the loader is configured with a default file extension. Now a `TemplateNotFoundError` is raised instead. See [#203](https://github.com/jg-rp/liquid/issues/203).
+- Fixed an issue with the built-in `FileSystemLoader` where a `ValueError` would be raised at render time if the configured default file extension is not a valid suffix. Now we raise a `ValueError` at `FileSystemLoader` construction time if the `ext` argument is not a valid suffix.
+
 ## Version 2.2.1
 
 Fixed `{% case %}` tags with no associated `{% when %}` or `{% else %}` tags, and no closing `{% endcase %}` tag. Previously a template such as `{% case x %}` would cause the parser to hang in an infinite loop.

--- a/liquid/builtin/loaders/file_system_loader.py
+++ b/liquid/builtin/loaders/file_system_loader.py
@@ -29,6 +29,9 @@ class FileSystemLoader(BaseLoader):
         ext: A default file extension. Should include a leading period.
         reject_symlinks: When `True`, reject paths to symlinks that resolve to files
             outside the search path. Defaults to `False`.
+
+    Raise:
+        ValueError if `ext` is not a valid suffix.
     """
 
     def __init__(
@@ -48,6 +51,10 @@ class FileSystemLoader(BaseLoader):
         self.ext = ext
         self.reject_symlinks = reject_symlinks
 
+        # Raise a ValueError early if `ext` is invalid.
+        if ext:
+            Path("x").with_suffix(ext)
+
     def resolve_path(self, template_name: str) -> Path:
         """Return a path to the template identified by _template_name_.
 
@@ -56,6 +63,9 @@ class FileSystemLoader(BaseLoader):
         _TemplateNotFound_ exception is raised.
         """
         template_path = Path(template_name)
+
+        if not template_path.name:
+            raise TemplateNotFoundError(template_name)
 
         if self.ext and not template_path.suffix:
             template_path = template_path.with_suffix(self.ext)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ packages = ["liquid"]
 
 [tool.hatch.envs.default]
 dependencies = [
+  "hypothesis",
   "pytest",
   "pytest-cov",
   "pytest-mock",

--- a/tests/test_file_system_loader.py
+++ b/tests/test_file_system_loader.py
@@ -327,3 +327,11 @@ def test_cache_capacity() -> None:
     _template = env.get_template("footer.liquid")
     assert len(loader.cache) == 2
     assert list(loader.cache.keys()) == ["footer.liquid", "header.liquid"]
+
+
+def test_invalid_suffix():
+    with pytest.raises(ValueError, match=r"Invalid suffix"):
+        FileSystemLoader(
+            "tests/fixtures/001/templates/",
+            ext="0",
+        )

--- a/tests/test_file_system_loader_properties.py
+++ b/tests/test_file_system_loader_properties.py
@@ -1,0 +1,29 @@
+import re
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from liquid import Environment
+from liquid import FileSystemLoader
+from liquid.exceptions import TemplateNotFoundError
+
+
+@pytest.fixture(scope="session")
+def env() -> Environment:
+    return Environment(
+        loader=FileSystemLoader(
+            "tests/fixtures/001/templates/",
+            ext=".liquid",
+        ),
+    )
+
+
+# Avoid syntax errors from escaped quotes.
+RE_RESERVED = re.compile(r"['\"]|[%}]\}")
+
+
+@given(st.text().filter(lambda s: not RE_RESERVED.search(s)))
+def test_filesystem_loader_handles_strings(env: Environment, text: str) -> None:
+    with pytest.raises(TemplateNotFoundError):
+        env.render(f"{{% render {repr(text)} %}}")

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,10 +1,43 @@
 import pytest
 
+from liquid import Environment
+from liquid import FileSystemLoader
 from liquid import parse
 from liquid.exceptions import LiquidSyntaxError
+from liquid.exceptions import TemplateNotFoundError
 
 
 def test_case_tag_raises_when_eof():
     # Before version 2.2.1 this would loop forever.
     with pytest.raises(LiquidSyntaxError):
         parse("{% case x %}")
+
+
+def test_issue_203():
+    env = Environment(
+        loader=FileSystemLoader(
+            "tests/fixtures/001/templates/",
+            ext=".liquid",
+        ),
+    )
+
+    # Specifically when `ext` is given, these were raising a ValueError
+    # when calling `with_suffix` if the path has an empty name.
+
+    with pytest.raises(TemplateNotFoundError):
+        env.render("{% render '' %}")
+
+    with pytest.raises(TemplateNotFoundError):
+        env.render("{% render '.' %}")
+
+    with pytest.raises(TemplateNotFoundError):
+        env.render("{% render './' %}")
+
+    with pytest.raises(TemplateNotFoundError):
+        env.render("{% include '' %}")
+
+    with pytest.raises(TemplateNotFoundError):
+        env.render("{% include '.' %}")
+
+    with pytest.raises(TemplateNotFoundError):
+        env.render("{% include './' %}")

--- a/tests/test_render_extra.py
+++ b/tests/test_render_extra.py
@@ -23,8 +23,8 @@ class Case:
     description: str
     template: str
     expect: str
-    globals: dict[str, Any] = field(default_factory=dict)  # noqa: A003
-    partials: dict[str, Any] = field(default_factory=dict)
+    globals: dict[str, Any] = field(default_factory=dict[str, Any])
+    partials: dict[str, Any] = field(default_factory=dict[str, Any])
     standard: bool = True
     error: bool = False
     strict: bool = False


### PR DESCRIPTION
- Fix a bug in the built-in `FileSystemLoader` where a `ValueError` would be raised at render time if the target file name is empty or, in some cases, contains only path punctuation **and** the loader is configured with a default file extension. Now a `TemplateNotFoundError` is raised instead.

- Raise a `ValueError` at `FileSystemLoader` construction time instead of render time if the `ext` argument is not a valid file suffix.

- Add some property-based testing for file names passed to the `{% render %}` tag.

See #203 