### PR TITLE
Handle `cycle` tags with no arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Fixed a bug in the built-in `FileSystemLoader` where a `ValueError` would be raised at render time if the target file name is empty or, in some cases, contains only path punctuation **and** the loader is configured with a default file extension. Now a `TemplateNotFoundError` is raised instead. See [#203](https://github.com/jg-rp/liquid/issues/203).
 - Fixed an issue with the built-in `FileSystemLoader` where a `ValueError` would be raised at render time if the configured default file extension is not a valid suffix. Now we raise a `ValueError` at `FileSystemLoader` construction time if the `ext` argument is not a valid suffix.
+- Fixed a bug with the `{% cycle %}` tag. Previously, if given a cycle group name without any other arguments, a `ZeroDivisionError` exception would be raised at render time. Now we raise a `LiquidSyntaxError` (we don't have a `TagArgumentError`) at parse time. See [#202](https://github.com/jg-rp/liquid/issues/202).
 
 ## Version 2.2.1
 

--- a/liquid/builtin/tags/cycle_tag.py
+++ b/liquid/builtin/tags/cycle_tag.py
@@ -11,6 +11,7 @@ from typing import TextIO
 from liquid.ast import Node
 from liquid.builtin.expressions import PositionalArgument
 from liquid.builtin.expressions import parse_primitive
+from liquid.exceptions import LiquidSyntaxError
 from liquid.stringify import to_liquid_string
 from liquid.tag import Tag
 from liquid.token import TOKEN_COLON
@@ -124,4 +125,8 @@ class CycleTag(Tag):
             tokens.eat(TOKEN_COLON)
 
         args = PositionalArgument.parse(self.env, tokens)
+
+        if not args:
+            raise LiquidSyntaxError("expected at least one argument", token=token)
+
         return self.node_class(token, group_name, [arg.value for arg in args])

--- a/liquid/context.py
+++ b/liquid/context.py
@@ -316,7 +316,7 @@ class RenderContext:
         """Return the index of the next item in the cycle."""
         namespace: dict[object, int] = self.tag_namespace["cycles"]
         idx = namespace.setdefault(key, 0)
-        namespace[key] = (idx + 1) % length
+        namespace[key] = (idx + 1) % (length or 1)  # Just in case.
         return idx
 
     def ifchanged(self, val: str) -> bool:

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -3,6 +3,7 @@ import pytest
 from liquid import Environment
 from liquid import FileSystemLoader
 from liquid import parse
+from liquid import render
 from liquid.exceptions import LiquidSyntaxError
 from liquid.exceptions import TemplateNotFoundError
 
@@ -11,6 +12,19 @@ def test_case_tag_raises_when_eof():
     # Before version 2.2.1 this would loop forever.
     with pytest.raises(LiquidSyntaxError):
         parse("{% case x %}")
+
+
+def test_issue_202():
+    # Before version 2.2.2 this would raise a ZeroDivisionError.
+    #
+    # Note that raising a syntax error here matches Shopify/liquid in strict2
+    # mode. Lax and strict mode silently ignore a `cycle` tag with no
+    # arguments.
+    with pytest.raises(LiquidSyntaxError):
+        render("{% cycle x: %}")
+
+    with pytest.raises(LiquidSyntaxError):
+        render("{% cycle %}")
 
 
 def test_issue_203():


### PR DESCRIPTION
Fix a bug with the `{% cycle %}` tag.

Previously, if given a cycle group name without any other arguments, a `ZeroDivisionError` exception would be raised at render time. Now we raise a `LiquidSyntaxError` (we don't have a `TagArgumentError`) at parse time.

See #202 