### PR TITLE
Handle bracketed root segments that resolve to non-string values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Fixed a bug in the built-in `FileSystemLoader` where a `ValueError` would be raised at render time if the target file name is empty or, in some cases, contains only path punctuation **and** the loader is configured with a default file extension. Now a `TemplateNotFoundError` is raised instead. See [#203](https://github.com/jg-rp/liquid/issues/203).
 - Fixed an issue with the built-in `FileSystemLoader` where a `ValueError` would be raised at render time if the configured default file extension is not a valid suffix. Now we raise a `ValueError` at `FileSystemLoader` construction time if the `ext` argument is not a valid suffix.
 - Fixed a bug with the `{% cycle %}` tag. Previously, if given a cycle group name without any other arguments, a `ZeroDivisionError` exception would be raised at render time. Now we raise a `LiquidSyntaxError` (we don't have a `TagArgumentError`) at parse time. See [#202](https://github.com/jg-rp/liquid/issues/202).
+- Fixed a bug where we'd get an `AssertionError` at render time when resolving variables using bracket syntax for the root segment and that segment evaluates to a non-string value. Now such uses of bracketed path syntax will be resolved to the configured `Undefined` type. See [#206](https://github.com/jg-rp/liquid/issues/206).
 
 ## Version 2.2.1
 

--- a/liquid/context.py
+++ b/liquid/context.py
@@ -175,7 +175,12 @@ class RenderContext:
         """
         it = iter(path)
         root = next(it)
-        assert isinstance(root, str)
+
+        if not isinstance(root, str):
+            if default == UNDEFINED:
+                hint = f"{root} is undefined"
+                return self.env.undefined(str(root), hint=hint, token=token)
+            return default
 
         try:
             obj = self.scope[root]

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -2,10 +2,12 @@ import pytest
 
 from liquid import Environment
 from liquid import FileSystemLoader
+from liquid import StrictUndefined
 from liquid import parse
 from liquid import render
 from liquid.exceptions import LiquidSyntaxError
 from liquid.exceptions import TemplateNotFoundError
+from liquid.exceptions import UndefinedError
 
 
 def test_case_tag_raises_when_eof():
@@ -14,7 +16,7 @@ def test_case_tag_raises_when_eof():
         parse("{% case x %}")
 
 
-def test_issue_202():
+def test_issue_202() -> None:
     # Before version 2.2.2 this would raise a ZeroDivisionError.
     #
     # Note that raising a syntax error here matches Shopify/liquid in strict2
@@ -27,7 +29,7 @@ def test_issue_202():
         render("{% cycle %}")
 
 
-def test_issue_203():
+def test_issue_203() -> None:
     env = Environment(
         loader=FileSystemLoader(
             "tests/fixtures/001/templates/",
@@ -55,3 +57,17 @@ def test_issue_203():
 
     with pytest.raises(TemplateNotFoundError):
         env.render("{% include './' %}")
+
+
+def test_issue_206() -> None:
+    source = "{{[[0]]}}"
+    assert render(source) == ""
+
+    # And with strict undefined.
+    env = Environment(undefined=StrictUndefined)
+
+    with pytest.raises(UndefinedError):
+        env.render(source)
+
+    # Variables that resolve to non-strings too.
+    assert render("{{ [x] }}", x=False) == ""


### PR DESCRIPTION
Fix a bug where we'd get an `AssertionError` at render time when resolving variables using bracket syntax for the root segment and that segment evaluates to a non-string value. Now such uses of bracketed path syntax will be resolved to the configured `Undefined` type.

See #206 