### PR TITLE
Add a block nesting resource limit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Python Liquid Change Log
 
+## Version 2.3.0 (unreleased)
+
+Added the `block_nesting_limit` class variable to `liquid.Environment` for handling excessive markup block nesting in Liquid templates. Previously we would get a `RecursionError` at render time if Python's recursion limit was reached. Now we raise a `BlockNestingError` (a subclass of `ResourceLimitError`) at parse time if `block_nesting_limit` is reached.
+
+The default `block_nesting_limit` is `30`. That's a maximum depth of 30 blocks per template source string or file.
+
+See [#208](https://github.com/jg-rp/liquid/issues/208).
+
 ## Version 2.2.2
 
 **Fixes**

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -185,6 +185,42 @@ template.render()
 # liquid.exceptions.LoopIterationLimitError: loop iteration limit reached
 ```
 
+### Block nesting limit
+
+**_New in version 2.3.0_**
+
+[`block_nesting_limit`](api/environment.md#liquid.Environment.block_nesting_limit) is the maximum number of nested blocks allowed before a `BlockNestingError` is raised. This helps us guard against templates that could otherwise exceed Python's recursion limit.
+
+The default `block_nesting_limit` is 30. That's per template source string or file, not the combined nesting of parent and included/rendered partial templates.
+
+!!! note
+
+    `BlockNestingError` inherits from `ResourceLimitError` and is raised at parse time, not render time.
+
+```python
+from liquid import Environment
+
+class MyEnvironment(Environment):
+    block_nesting_limit = 3  # Very low, for demonstration purposes.
+
+env = MyEnvironment()
+
+template = env.from_string(
+    (
+        "{% if true %}"
+        "  {% if true %}"
+        "    {% if true %}"
+        "      {% if true %}"
+        "      {% endif %}"
+        "    {% endif %}"
+        "  {% endif %}"
+        "{% endif %}"
+    )
+)
+
+# liquid.exceptions.BlockNestingError: block nesting limit reached
+```
+
 ### Context depth limit
 
 [`context_depth_limit`](api/environment.md#liquid.Environment.context_depth_limit) is the maximum number of times a render context can be extended or wrapped before a `ContextDepthError` is raised. This helps us guard against recursive use of the `include` and `render` tags. The default context depth limit is 30.

--- a/liquid/__init__.py
+++ b/liquid/__init__.py
@@ -56,7 +56,7 @@ from .tag import Tag
 
 from . import future
 
-__version__ = "2.2.2"
+__version__ = "2.3.0"
 
 __all__ = (
     "AwareBoundTemplate",

--- a/liquid/builtin/tags/liquid_tag.py
+++ b/liquid/builtin/tags/liquid_tag.py
@@ -127,7 +127,8 @@ class LiquidTag(Tag):
                     self._tokenize(
                         token_.value,
                         token=token_,
-                    )
+                    ),
+                    block_depth_carry=stream.block_depth,
                 ),
                 end=(),
             )

--- a/liquid/environment.py
+++ b/liquid/environment.py
@@ -18,6 +18,7 @@ from . import builtin
 from .analyze_tags import InnerTagMap
 from .analyze_tags import TagAnalysis
 from .builtin import DictLoader
+from .exceptions import BlockNestingError
 from .exceptions import LiquidError
 from .exceptions import LiquidSyntaxError
 from .exceptions import TemplateInheritanceError
@@ -78,6 +79,10 @@ class Environment:
         globals: An optional mapping that will be added to the render context of any
             template loaded from this environment.
     """
+
+    block_nesting_limit: ClassVar[int] = 30
+    """The maximum markup block nesting depth allowed before a `BlockNestingError`
+    exception is raised."""
 
     context_depth_limit: ClassVar[int] = 30
     """The maximum number of times a render context can be extended or wrapped before
@@ -275,7 +280,7 @@ class Environment:
         """
         try:
             nodes = self._parse(source)
-        except (LiquidSyntaxError, TemplateInheritanceError) as err:
+        except (LiquidSyntaxError, TemplateInheritanceError, BlockNestingError) as err:
             err.template_name = path
             raise err
         except Exception as err:  # noqa: BLE001

--- a/liquid/exceptions.py
+++ b/liquid/exceptions.py
@@ -191,6 +191,10 @@ class ResourceLimitError(LiquidError):
     """Base class for exceptions relating to resource limits."""
 
 
+class BlockNestingError(ResourceLimitError):
+    """The exception raised when block nesting limit is reached."""
+
+
 class ContextDepthError(ResourceLimitError):
     """Exception raised when the maximum context depth is reached.
 

--- a/liquid/parser.py
+++ b/liquid/parser.py
@@ -9,6 +9,7 @@ from typing import Iterator
 
 from .ast import BlockNode
 from .ast import Node
+from .exceptions import BlockNestingError
 from .exceptions import LiquidError
 from .token import TOKEN_COMMENT
 from .token import TOKEN_CONTENT
@@ -69,6 +70,10 @@ class Parser:
         output = tags[TOKEN_OUTPUT]
 
         nodes: list[Node] = []
+        stream.block_depth += 1
+
+        if stream.block_depth > self.env.block_nesting_limit:
+            raise BlockNestingError("block nesting limit reached", token=None)
 
         while stream.current.kind != TOKEN_EOF:
             if stream.current.kind == TOKEN_TAG and stream.current.value in end:
@@ -92,6 +97,7 @@ class Parser:
 
             next(stream)
 
+        stream.block_depth -= 1
         return BlockNode(stream.current, nodes)
 
 

--- a/liquid/stream.py
+++ b/liquid/stream.py
@@ -18,12 +18,10 @@ class TokenStream:
 
     eof = Token(TOKEN_EOF, TOKEN_EOF, -1, "")
 
-    def __init__(
-        self,
-        tokens: Iterator[Token],
-    ):
+    def __init__(self, tokens: Iterator[Token], block_depth_carry: int = 0):
         self.tokens = list(tokens)
         self.pos = 0
+        self.block_depth = block_depth_carry
 
     def __next__(self) -> Token:
         return self.next_token()

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -5,6 +5,7 @@ from liquid import FileSystemLoader
 from liquid import StrictUndefined
 from liquid import parse
 from liquid import render
+from liquid.exceptions import BlockNestingError
 from liquid.exceptions import LiquidSyntaxError
 from liquid.exceptions import TemplateNotFoundError
 from liquid.exceptions import UndefinedError
@@ -71,3 +72,10 @@ def test_issue_206() -> None:
 
     # Variables that resolve to non-strings too.
     assert render("{{ [x] }}", x=False) == ""
+
+
+def test_issue_208() -> None:
+    parse(f"{{% {'liquid ' * 30} echo 1 %}}")
+
+    with pytest.raises(BlockNestingError):
+        render(f"{{% {'liquid ' * 31} echo 1 %}}")

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -6,6 +6,7 @@ import pytest
 
 from liquid import DictLoader
 from liquid import Environment
+from liquid.exceptions import BlockNestingError
 from liquid.exceptions import ContextDepthError
 from liquid.exceptions import LocalNamespaceLimitError
 from liquid.exceptions import LoopIterationLimitError
@@ -307,3 +308,50 @@ def test_set_output_stream_limit() -> None:
 
     with pytest.raises(OutputStreamLimitError):
         template.render()
+
+
+def test_block_nesting_limit() -> None:
+    """Test that we handle excessive block nesting before hitting the recursion
+    limit."""
+
+    class MockEnv(Environment):
+        block_nesting_limit = 3
+
+    env = MockEnv()
+
+    env.from_string("{% if true %}{% endif %}")
+    env.from_string("{% if true %}{% if true %}{% endif %}{% endif %}")
+    env.from_string(
+        "{% if true %}{% if true %}{% if true %}{% endif %}{% endif %}{% endif %}"
+    )
+
+    with pytest.raises(BlockNestingError):
+        env.from_string(
+            (
+                "{% if true %}"
+                "  {% if true %}"
+                "    {% if true %}"
+                "      {% if true %}"
+                "      {% endif %}"
+                "    {% endif %}"
+                "  {% endif %}"
+                "{% endif %}"
+            )
+        )
+
+
+def test_block_nesting_limit_with_liquid_tag() -> None:
+    class MockEnv(Environment):
+        block_nesting_limit = 3
+
+    env = MockEnv()
+
+    env.from_string("{% if true %}{% endif %}")
+    env.from_string("{% if true %}{% liquid liquid echo 1 %}{% endif %}")
+    env.from_string("{% liquid liquid liquid echo 1 %}")
+
+    with pytest.raises(BlockNestingError):
+        env.from_string("{% if true %}{% liquid liquid liquid echo 1 %}{% endif %}")
+
+    with pytest.raises(BlockNestingError):
+        env.from_string("{% liquid liquid liquid liquid echo 1 %}")


### PR DESCRIPTION
The PR adds a `block_nesting_limit` class variable to `liquid.Environment` for handling excessive markup block nesting in Liquid templates. Previously we would get a `RecursionError` at render time if Python's recursion limit was reached. Now we raise a `BlockNestingError` (a subclass of `ResourceLimitError`) at parse time if `block_nesting_limit` is reached.

The default `block_nesting_limit` is `30`. That's a maximum depth of 30 blocks per template source string or file.

The choice of 30 is somewhat arbitrary. It's hard to imagine a legitimate need for more than 5 levels of nesting.

Closes #208